### PR TITLE
feat(inventory): Add multiprocessing for inventory discovery

### DIFF
--- a/anta/inventory/__init__.py
+++ b/anta/inventory/__init__.py
@@ -138,7 +138,7 @@ class AntaInventory():
 
     def _is_device_online(self, device: InventoryDevice, timeout: float = 5):
         """
-        _is_online Check if device is online.
+        _is_device_online Check if device is online.
 
         Execute an eAPI call to check if device is online and has eAPI working as expected
         If device is ready to serve request, method returns True, else return False.
@@ -382,6 +382,11 @@ class AntaInventory():
     ### MISC methods
 
     def refresh_online_flag_inventory(self):
+        """
+        refresh_online_flag_inventory Update is_online flag for all devices.
+
+        Execute in parallel a call to _refresh_online_flag_device to test device connectivity.
+        """
         logger.debug(f'Refreshing is_online flag in current inventory')
         with Pool(processes=multiprocessing.cpu_count()) as pool:
             logger.debug(f'Refreshing is_online flag in current inventory')

--- a/anta/inventory/__init__.py
+++ b/anta/inventory/__init__.py
@@ -10,6 +10,8 @@ import ssl
 from socket import setdefaulttimeout
 from typing import List
 import yaml
+import multiprocessing
+from multiprocessing import Pool
 from jinja2 import Template
 from jsonrpclib import ProtocolError, Server, jsonrpc
 from netaddr import IPNetwork, IPAddress
@@ -45,7 +47,7 @@ class AntaInventory():
     Inventory Output:
     ------------------
     >>> test = AntaInventory(inventory_file='examples/inventory.yml',username='ansible', password='ansible', auto_connect=True)
-    >>> test.inventory_get()
+    >>> test.get_inventory()
     >>> [
     >>>     "InventoryDevice(host=IPv4Address('192.168.0.17')",
     >>>     "username='ansible'",
@@ -71,7 +73,7 @@ class AntaInventory():
     INVENTORY_OUTPUT_FORMAT = ['native', 'json']
 
     # pylint: disable=R0913
-    def __init__(self, inventory_file: str, username: str, password: str, auto_connect: bool = True, timeout: int = 5):
+    def __init__(self, inventory_file: str, username: str, password: str, auto_connect: bool = True, timeout: float = 5):
         """Class constructor.
 
         Args:
@@ -79,7 +81,7 @@ class AntaInventory():
             username (str): Username to use to connect to devices
             password (str): Password to use to connect to devices
             auto_connect (bool, optional): Automatically build eAPI context for every devices. Defaults to True.
-            timeout (int, optional): Timeout in second to wait before marking device down. Defaults to 5sec.
+            timeout (float, optional): Timeout in second to wait before marking device down. Defaults to 5sec.
         """
         self._username = username
         self._password = password
@@ -111,7 +113,12 @@ class AntaInventory():
 
         # Create RPC connection for all devices
         if auto_connect:
-            self.sessions_create()
+            self.refresh_online_flag_inventory()
+            self.create_all_sessions()
+
+    ###########################################################################
+    ### Boolean methods
+    ###########################################################################
 
     def _is_ip_exist(self, ip: str):
         """Check if an IP is part of the current inventory.
@@ -122,22 +129,56 @@ class AntaInventory():
         Returns:
             bool: True if device is in our inventory, False if not
         """
+        logger.debug(f'Checking if device {ip} is in ourr inventory')
         return len([str(dev.host) for dev in self._inventory if str(ip) == str(dev.host)]) == 1
 
-    def device_get(self, host_ip):
-        """Get device information from a given IP.
+    def _is_device_online(self, device: InventoryDevice, timeout: float = 5):
+        """
+        _is_online Check if device is online.
+
+        Execute an eAPI call to check if device is online and has eAPI working as expected
+        If device is ready to serve request, method returns True, else return False.
 
         Args:
-            host_ip (str): IP address of the device
+            device (InventoryDevice): InventoryDevice structure to test
+            timeout (float, optional): Request timeout. Defaults to 5.
 
         Returns:
-            InventoryDevice: Device information
+            bool: True if device ready, False by default.
         """
-        if self._is_ip_exist(host_ip):
-            return [dev for dev in self._inventory if str(dev.host) == str(host_ip)][0]
-        return None
+        logger.debug(f'Checking if device {device.host} is online')
+        connection = Server(device.url)
+        # Check connectivity
+        try:
+            setdefaulttimeout(timeout)
+            connection.runCmds(1,['show version'])
+        # pylint: disable=W0703
+        except Exception:
+            logger.warning(f'Service not running on device {device.host}')
+            return False
+        else:
+            return True
 
-    def _session_build_path(self, host: str, username: str, password: str):
+    ###########################################################################
+    ### Internal methods
+    ###########################################################################
+
+    def _refresh_online_flag_device(self, device: InventoryDevice):
+        """
+        _refresh_online_flag_device Update online flag for InventoryDevice
+
+        Args:
+            device (InventoryDevice): Device to check using InventoryDevice structure.
+
+        Returns:
+            InventoryDevice: Updated structure with valid online key
+        """
+        logger.debug(f'Refreshing is_online flag for device {device.host}')
+        device.is_online = self._is_device_online(
+            device=device, timeout=self.timeout)
+        return device
+
+    def _build_device_session_path(self, host: str, username: str, password: str):
         """Construct URL to reach device using eAPI.
 
         Jinja2 render to build URL to use for eAPI session.
@@ -155,9 +196,9 @@ class AntaInventory():
             device=host,
             device_username=username,
             device_password=password
-         )
+        )
 
-    def _session_create(self, device : InventoryDevice, timeout: int = 5):
+    def _build_device_session(self, device: InventoryDevice, timeout: float = 5):
         """Create eAPI RPC session to Arista EOS devices.
 
         Args:
@@ -171,7 +212,7 @@ class AntaInventory():
         # Check connectivity
         try:
             setdefaulttimeout(timeout)
-            connection.runCmds(1,['show version'])
+            connection.runCmds(1, ['show version'])
         # pylint: disable=W0703
         except Exception:
             logger.warning(f'Service not running on device {device.host}')
@@ -181,51 +222,7 @@ class AntaInventory():
             device.session = connection
         return device
 
-    def session_create(self, host_ip: str):
-        """Get session of a device.
-
-        If device has already a session, function only returns active session, if not, try to build a new session
-
-        Args:
-            host_ip (str): IP address of the device
-
-        Returns:
-            bool: True if update succeed, False if not
-        """
-        logger.debug(f'Searching for device {host_ip} in {[str(dev.host) for dev in self._inventory]}')
-        if len([dev for dev in self._inventory if str(dev.host) == str(host_ip)])>0:
-            device = [dev for dev in self._inventory if str(dev.host) == str(host_ip)][0]
-            logger.debug(f'Search result is: {device}')
-            if not device.established and self._is_ip_exist(host_ip):
-                logger.debug(f'Trying to connect to device {str(device.host)}')
-                device = self._session_create(device=device, timeout=self.timeout)
-                # pylint: disable=W0104
-                [device if dev.host == device.host else dev for dev in self._inventory]
-                return True
-        return False
-
-    def session_get(self, host_ip: str):
-        """Expose RPC session of a given host from our inventory.
-
-        Provide RPC session if the session exists, if not, it returns None
-
-        Args:
-            host_ip (str): IP address of the host to match
-
-        Returns:
-            jsonrpclib.Server: Instance to the device. None if session does not exist
-        """
-        device = self.device_get(host_ip=host_ip)
-        if device is None:
-            return None
-        return device.session
-
-    def sessions_create(self):
-        """Helper to build RPC sessions to all devices"""
-        for device in self._inventory:
-            self.session_create(host_ip=device.host)
-
-    def _inventory_add_device(self, host_ip):
+    def _add_device_to_inventory(self, host_ip):
         """Add a InventoryDevice to final inventory.
 
         Create InventoryDevice and append to existing inventory
@@ -237,7 +234,7 @@ class AntaInventory():
             host=host_ip,
             username=self._username,
             password=self._password,
-            url=self._session_build_path(
+            url=self._build_device_session_path(
                 host=host_ip,
                 username=self._username,
                 password=self._password
@@ -251,7 +248,7 @@ class AntaInventory():
         Build InventoryDevice structure for all hosts under hosts section
         """
         for host in self._read_inventory.hosts:
-            self._inventory_add_device(host_ip=host.host)
+            self._add_device_to_inventory(host_ip=host.host)
 
     def _inventory_read_networks(self):
         """Read input data from networks section and create inventory structure.
@@ -260,7 +257,7 @@ class AntaInventory():
         """
         for network in self._read_inventory.networks:
             for host_ip in IPNetwork(str(network.network)):
-                self._inventory_add_device(host_ip=host_ip)
+                self._add_device_to_inventory(host_ip=host_ip)
 
     def _inventory_read_ranges(self):
         """Read input data from ranges section and create inventory structure.
@@ -271,11 +268,18 @@ class AntaInventory():
             range_increment = IPAddress(str(range_def.start))
             range_stop = IPAddress(str(range_def.end))
             while range_increment <= range_stop:
-                self._inventory_add_device(host_ip=str(range_increment))
+                self._add_device_to_inventory(host_ip=str(range_increment))
                 range_increment += 1
 
-    def inventory_get(self, format_out: str = 'native', established_only: bool = True):
-        """inventory_get Expose device inventory.
+    ###########################################################################
+    ### Public methods
+    ###########################################################################
+
+    ###########################################################################
+    ### GET methods
+
+    def get_inventory(self, format_out: str = 'native', established_only: bool = True):
+        """get_inventory Expose device inventory.
 
         Provides inventory has a list of InventoryDevice objects. If requried, it can be exposed in JSON format. Also, by default expose only active devices.
 
@@ -298,3 +302,89 @@ class AntaInventory():
         if format_out == 'json':
             return self._inventory.json()
         return devices
+
+    def get_device(self, host_ip):
+        """Get device information from a given IP.
+
+        Args:
+            host_ip (str): IP address of the device
+
+        Returns:
+            InventoryDevice: Device information
+        """
+        if self._is_ip_exist(host_ip):
+            return [dev for dev in self._inventory if str(dev.host) == str(host_ip)][0]
+        return None
+
+    def get_device_session(self, host_ip: str):
+        """Expose RPC session of a given host from our inventory.
+
+        Provide RPC session if the session exists, if not, it returns None
+
+        Args:
+            host_ip (str): IP address of the host to match
+
+        Returns:
+            jsonrpclib.Server: Instance to the device. None if session does not exist
+        """
+        device = self.get_device(host_ip=host_ip)
+        if device is None:
+            return None
+        return device.session
+
+    ###########################################################################
+    ### CREATE methods
+
+    def create_all_sessions(self, refresh_online_first: bool = False):
+        """Helper to build RPC sessions to all devices.
+
+         Args:
+            refresh_online_first (bool): Run  a refresh of is_online flag for all devices.
+        """
+        if refresh_online_first:
+            logger.debug(f'Running a refresh for devices online')
+            self.refresh_online_flag_inventory()
+
+        for device in self._inventory:
+            self.create_device_session(host_ip=device.host)
+
+    def create_device_session(self, host_ip: str):
+        """Get session of a device.
+
+        If device has already a session, function only returns active session, if not, try to build a new session
+
+        Args:
+            host_ip (str): IP address of the device
+
+        Returns:
+            bool: True if update succeed, False if not
+        """
+        logger.debug(
+            f'Searching for device {host_ip} in {[str(dev.host) for dev in self._inventory]}')
+        if len([dev for dev in self._inventory if str(dev.host) == str(host_ip)]) > 0:
+            device = [dev for dev in self._inventory if str(
+                dev.host) == str(host_ip)][0]
+            logger.debug(f'Search result is: {device}')
+            if device.is_online and not device.established and self._is_ip_exist(host_ip):
+                logger.debug(f'Trying to connect to device {str(device.host)}')
+                device = self._build_device_session(
+                    device=device, timeout=self.timeout)
+                # pylint: disable=W0104
+                [device if dev.host == device.host else dev for dev in self._inventory]
+                return True
+        return False
+
+    ###########################################################################
+    ### MISC methods
+
+    def refresh_online_flag_inventory(self):
+        logger.debug(f'Refreshing is_online flag in current inventory')
+        pool = Pool(processes=multiprocessing.cpu_count())
+        logger.debug(f'Refreshing is_online flag in current inventory')
+        logger.debug(f'  * Check devices using multiprocessing')
+        results_map = pool.map(
+            self._refresh_online_flag_device,  self._inventory)
+        self._inventory = InventoryDevices()
+        logger.debug(f'  * Rebuild inventory')
+        for device in results_map:
+            self._inventory.append(device)

--- a/anta/inventory/__init__.py
+++ b/anta/inventory/__init__.py
@@ -77,7 +77,7 @@ class AntaInventory():
     INVENTORY_OUTPUT_FORMAT = ['native', 'json']
 
     # pylint: disable=R0913
-    def __init__(self, inventory_file: str, username: str, password: str, auto_connect: bool = True, timeout: float = 5):
+    def __init__(self, inventory_file: str, username: str, password: str, auto_connect: bool = True, timeout: float = 5) -> None:
         """Class constructor.
 
         Args:
@@ -124,7 +124,7 @@ class AntaInventory():
     ### Boolean methods
     ###########################################################################
 
-    def _is_ip_exist(self, ip: str):
+    def _is_ip_exist(self, ip: str) -> bool:
         """Check if an IP is part of the current inventory.
 
         Args:
@@ -136,7 +136,7 @@ class AntaInventory():
         logger.debug(f'Checking if device {ip} is in ourr inventory')
         return len([str(dev.host) for dev in self._inventory if str(ip) == str(dev.host)]) == 1
 
-    def _is_device_online(self, device: InventoryDevice, timeout: float = 5):
+    def _is_device_online(self, device: InventoryDevice, timeout: float = 5) -> bool:
         """
         _is_device_online Check if device is online.
 
@@ -167,7 +167,7 @@ class AntaInventory():
     ### Internal methods
     ###########################################################################
 
-    def _refresh_online_flag_device(self, device: InventoryDevice):
+    def _refresh_online_flag_device(self, device: InventoryDevice) -> InventoryDevice:
         """
         _refresh_online_flag_device Update online flag for InventoryDevice
 
@@ -182,7 +182,7 @@ class AntaInventory():
             device=device, timeout=self.timeout)
         return device
 
-    def _build_device_session_path(self, host: str, username: str, password: str):
+    def _build_device_session_path(self, host: str, username: str, password: str) -> str:
         """Construct URL to reach device using eAPI.
 
         Jinja2 render to build URL to use for eAPI session.
@@ -202,7 +202,7 @@ class AntaInventory():
             device_password=password
         )
 
-    def _build_device_session(self, device: InventoryDevice, timeout: float = 5):
+    def _build_device_session(self, device: InventoryDevice, timeout: float = 5) -> InventoryDevice:
         """Create eAPI RPC session to Arista EOS devices.
 
         Args:
@@ -226,7 +226,7 @@ class AntaInventory():
             device.session = connection
         return device
 
-    def _add_device_to_inventory(self, host_ip):
+    def _add_device_to_inventory(self, host_ip) -> None:
         """Add a InventoryDevice to final inventory.
 
         Create InventoryDevice and append to existing inventory
@@ -246,7 +246,7 @@ class AntaInventory():
         )
         self._inventory.append(device)
 
-    def _inventory_read_hosts(self):
+    def _inventory_read_hosts(self) -> None:
         """Read input data from hosts section and create inventory structure.
 
         Build InventoryDevice structure for all hosts under hosts section
@@ -254,7 +254,7 @@ class AntaInventory():
         for host in self._read_inventory.hosts:
             self._add_device_to_inventory(host_ip=host.host)
 
-    def _inventory_read_networks(self):
+    def _inventory_read_networks(self) -> None:
         """Read input data from networks section and create inventory structure.
 
         Build InventoryDevice structure for all IPs available in each declared subnet
@@ -263,7 +263,7 @@ class AntaInventory():
             for host_ip in IPNetwork(str(network.network)):
                 self._add_device_to_inventory(host_ip=host_ip)
 
-    def _inventory_read_ranges(self):
+    def _inventory_read_ranges(self) -> None:
         """Read input data from ranges section and create inventory structure.
 
         Build InventoryDevice structure for all IPs available in each declared range
@@ -275,6 +275,23 @@ class AntaInventory():
                 self._add_device_to_inventory(host_ip=str(range_increment))
                 range_increment += 1
 
+    def _inventory_rebuild(self, list_devices: List[InventoryDevice]) -> InventoryDevices:
+        """
+        _inventory_rebuild Transform a list of InventoryDevice into a InventoryDevices object.
+
+        Args:
+            list_devices (List[InventoryDevice]): List of devices to add into InventoryDevices
+
+        Returns:
+            InventoryDevices: An object with all the devices.
+        """
+        logger.debug(f'Create a new version of InventoryDevices')
+        inventory = InventoryDevices()
+        for device in list_devices:
+            inventory.append(device)
+        return inventory
+
+
     ###########################################################################
     ### Public methods
     ###########################################################################
@@ -282,7 +299,7 @@ class AntaInventory():
     ###########################################################################
     ### GET methods
 
-    def get_inventory(self, format_out: str = 'native', established_only: bool = True):
+    def get_inventory(self, format_out: str = 'native', established_only: bool = True) -> InventoryDevices:
         """get_inventory Expose device inventory.
 
         Provides inventory has a list of InventoryDevice objects. If requried, it can be exposed in JSON format. Also, by default expose only active devices.
@@ -292,7 +309,7 @@ class AntaInventory():
             established_only (bool, optional): Allow to expose also unreachable devices. Defaults to True.
 
         Returns:
-            List: List of InventoryDevice
+            InventoryDevices: List of InventoryDevice
         """
         if format_out not in ['native', 'json']:
             raise InventoryUnknownFormat(
@@ -307,7 +324,7 @@ class AntaInventory():
             return self._inventory.json()
         return devices
 
-    def get_device(self, host_ip):
+    def get_device(self, host_ip) -> InventoryDevice:
         """Get device information from a given IP.
 
         Args:
@@ -320,7 +337,7 @@ class AntaInventory():
             return [dev for dev in self._inventory if str(dev.host) == str(host_ip)][0]
         return None
 
-    def get_device_session(self, host_ip: str):
+    def get_device_session(self, host_ip: str) -> Server:
         """Expose RPC session of a given host from our inventory.
 
         Provide RPC session if the session exists, if not, it returns None
@@ -339,7 +356,7 @@ class AntaInventory():
     ###########################################################################
     ### CREATE methods
 
-    def create_all_sessions(self, refresh_online_first: bool = False):
+    def create_all_sessions(self, refresh_online_first: bool = False) -> None:
         """Helper to build RPC sessions to all devices.
 
          Args:
@@ -352,7 +369,7 @@ class AntaInventory():
         for device in self._inventory:
             self.create_device_session(host_ip=device.host)
 
-    def create_device_session(self, host_ip: str):
+    def create_device_session(self, host_ip: str) -> bool:
         """Get session of a device.
 
         If device has already a session, function only returns active session, if not, try to build a new session
@@ -381,7 +398,7 @@ class AntaInventory():
     ###########################################################################
     ### MISC methods
 
-    def refresh_online_flag_inventory(self):
+    def refresh_online_flag_inventory(self) -> None:
         """
         refresh_online_flag_inventory Update is_online flag for all devices.
 
@@ -390,10 +407,8 @@ class AntaInventory():
         logger.debug(f'Refreshing is_online flag in current inventory')
         with Pool(processes=multiprocessing.cpu_count()) as pool:
             logger.debug(f'Refreshing is_online flag in current inventory')
-            logger.debug(f'  * Check devices using multiprocessing')
+            logger.debug(f'Check devices using multiprocessing')
             results_map = pool.map(
                 self._refresh_online_flag_device,  self._inventory)
-            self._inventory = InventoryDevices()
-            logger.debug(f'  * Rebuild inventory')
-            for device in results_map:
-                self._inventory.append(device)
+            logger.debug(f'Update inventory with updated data')
+            self._inventory = self._inventory_rebuild(results_map)

--- a/anta/inventory/__init__.py
+++ b/anta/inventory/__init__.py
@@ -405,7 +405,8 @@ class AntaInventory():
         Execute in parallel a call to _refresh_online_flag_device to test device connectivity.
         """
         logger.debug(f'Refreshing is_online flag in current inventory')
-        with Pool(processes=multiprocessing.cpu_count()) as pool:
+        number_of_devices = len([dev.host for dev in self._inventory])
+        with Pool(processes=number_of_devices) as pool:
             logger.debug(f'Refreshing is_online flag in current inventory')
             logger.debug(f'Check devices using multiprocessing')
             results_map = pool.map(

--- a/anta/inventory/models.py
+++ b/anta/inventory/models.py
@@ -38,6 +38,7 @@ class InventoryDevice(BaseModel):
     password: str
     session: Any
     established = False
+    is_online = False
     url: str
 
 class InventoryDevices(BaseModel):

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -20,6 +20,7 @@
 - [`models.AntaInventoryNetwork`](./inventory.models.md#class-antainventorynetwork): Network definition for user's inventory.
 - [`models.AntaInventoryRange`](./inventory.models.md#class-antainventoryrange): IP Range definition for user's inventory.
 - [`models.InventoryDevice`](./inventory.models.md#class-inventorydevice): Inventory model exposed by Inventory class.
+- [`models.InventoryDevices`](./inventory.models.md#class-inventorydevices): Inventory model to list all InventoryDevice entries.
 
 ## Functions
 

--- a/docs/api/inventory.exceptions.md
+++ b/docs/api/inventory.exceptions.md
@@ -9,7 +9,7 @@ Manage Exception in Inventory module.
 
 ---
 
-<a href="../../anta/inventory/exceptions.py#L8"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../anta/inventory/exceptions.py#L7"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `InventoryRootKeyErrors`
 Error raised when inventory root key is not found. 
@@ -20,7 +20,7 @@ Error raised when inventory root key is not found.
 
 ---
 
-<a href="../../anta/inventory/exceptions.py#L12"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../anta/inventory/exceptions.py#L10"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `InventoryIncorrectSchema`
 Error when user data does not follow ANTA schema. 
@@ -31,7 +31,7 @@ Error when user data does not follow ANTA schema.
 
 ---
 
-<a href="../../anta/inventory/exceptions.py#L16"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../anta/inventory/exceptions.py#L13"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `InventoryUnknownFormat`
 Error when inventory format output is not a supported one. 

--- a/docs/api/inventory.md
+++ b/docs/api/inventory.md
@@ -7,16 +7,16 @@ Inventory Module for ANTA.
 
 **Global Variables**
 ---------------
+- **exceptions**: # coding: utf-8 -*-
+
 - **models**: # -*- coding: utf-8 -*-
 # pylint: skip-file
-
-- **exceptions**: # coding: utf-8 -*-
 
 
 
 ---
 
-<a href="../../anta/inventory/__init__.py#L25"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../anta/inventory/__init__.py#L34"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `AntaInventory`
 Inventory Abstraction for ANTA framework. 
@@ -32,7 +32,7 @@ Inventory file example:
 Inventory Output:
 
 ------------------
-``` test = AntaInventory(inventory_file='examples/inventory.yml',username='ansible', password='ansible', auto_connect=True)``` ``` test.inventory_get()```
+``` test = AntaInventory(inventory_file='examples/inventory.yml',username='ansible', password='ansible', auto_connect=True)``` ``` test.get_inventory()```
 ``` [``` ```     "InventoryDevice(host=IPv4Address('192.168.0.17')",```
 ```     "username='ansible'",``` ```     "password='ansible'",```
 ```     "session=<ServerProxy for ansible:ansible@192.168.0.17/command-api>",``` ```     "url='https://ansible:ansible@192.168.0.17/command-api'",```
@@ -44,7 +44,7 @@ Inventory Output:
 ```     "established=False"``` ``` ]```
 
 
-<a href="../../anta/inventory/__init__.py#L70"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../anta/inventory/__init__.py#L80"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `AntaInventory.__init__`
 
@@ -53,8 +53,9 @@ __init__(
     inventory_file: str,
     username: str,
     password: str,
-    auto_connect: bool = True
-)
+    auto_connect: bool = True,
+    timeout: float = 5
+) → None
 ```
 
 Class constructor. 
@@ -67,69 +68,37 @@ Class constructor.
  - <b>`username`</b> (str):  Username to use to connect to devices 
  - <b>`password`</b> (str):  Password to use to connect to devices 
  - <b>`auto_connect`</b> (bool, optional):  Automatically build eAPI context for every devices. Defaults to True. 
+ - <b>`timeout`</b> (float, optional):  Timeout in second to wait before marking device down. Defaults to 5sec. 
 
 
 
 
 ---
 
-<a href="../../anta/inventory/__init__.py#L122"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../anta/inventory/__init__.py#L359"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
-### <kbd>method</kbd> `AntaInventory.device_get`
+### <kbd>method</kbd> `AntaInventory.create_all_sessions`
 
 ```python
-device_get(host_ip)
+create_all_sessions(refresh_online_first: bool = False) → None
 ```
 
-Get device information from a given IP. 
+Helper to build RPC sessions to all devices. 
 
 
 
 **Args:**
  
- - <b>`host_ip`</b> (str):  IP address of the device 
-
-
-
-**Returns:**
- 
- - <b>`InventoryDevice`</b>:  Device information 
+ - <b>`refresh_online_first`</b> (bool):  Run  a refresh of is_online flag for all devices. 
 
 ---
 
-<a href="../../anta/inventory/__init__.py#L269"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../anta/inventory/__init__.py#L372"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
-### <kbd>method</kbd> `AntaInventory.inventory_get`
-
-```python
-inventory_get(format_out: str = 'native', established_only: bool = True)
-```
-
-inventory_get Expose device inventory. 
-
-Provides inventory has a list of InventoryDevice objects. If requried, it can be exposed in JSON format. Also, by default expose only active devices. 
-
-
-
-**Args:**
- 
- - <b>`format`</b> (str, optional):  Format output, can be native or JSON. Defaults to 'native'. 
- - <b>`established_only`</b> (bool, optional):  Allow to expose also unreachable devices. Defaults to True. 
-
-
-
-**Returns:**
- 
- - <b>`List`</b>:  List of InventoryDevice 
-
----
-
-<a href="../../anta/inventory/__init__.py#L179"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
-
-### <kbd>method</kbd> `AntaInventory.session_create`
+### <kbd>method</kbd> `AntaInventory.create_device_session`
 
 ```python
-session_create(host_ip: str)
+create_device_session(host_ip: str) → bool
 ```
 
 Get session of a device. 
@@ -150,12 +119,36 @@ If device has already a session, function only returns active session, if not, t
 
 ---
 
-<a href="../../anta/inventory/__init__.py#L199"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../anta/inventory/__init__.py#L327"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
-### <kbd>method</kbd> `AntaInventory.session_get`
+### <kbd>method</kbd> `AntaInventory.get_device`
 
 ```python
-session_get(host_ip: str)
+get_device(host_ip) → InventoryDevice
+```
+
+Get device information from a given IP. 
+
+
+
+**Args:**
+ 
+ - <b>`host_ip`</b> (str):  IP address of the device 
+
+
+
+**Returns:**
+ 
+ - <b>`InventoryDevice`</b>:  Device information 
+
+---
+
+<a href="../../anta/inventory/__init__.py#L340"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>method</kbd> `AntaInventory.get_device_session`
+
+```python
+get_device_session(host_ip: str) → ServerProxy
 ```
 
 Expose RPC session of a given host from our inventory. 
@@ -176,15 +169,47 @@ Provide RPC session if the session exists, if not, it returns None
 
 ---
 
-<a href="../../anta/inventory/__init__.py#L215"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../../anta/inventory/__init__.py#L302"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
-### <kbd>method</kbd> `AntaInventory.sessions_create`
+### <kbd>method</kbd> `AntaInventory.get_inventory`
 
 ```python
-sessions_create()
+get_inventory(
+    format_out: str = 'native',
+    established_only: bool = True
+) → InventoryDevices
 ```
 
-Helper to build RPC sessions to all devices 
+get_inventory Expose device inventory. 
+
+Provides inventory has a list of InventoryDevice objects. If requried, it can be exposed in JSON format. Also, by default expose only active devices. 
+
+
+
+**Args:**
+ 
+ - <b>`format`</b> (str, optional):  Format output, can be native or JSON. Defaults to 'native'. 
+ - <b>`established_only`</b> (bool, optional):  Allow to expose also unreachable devices. Defaults to True. 
+
+
+
+**Returns:**
+ 
+ - <b>`InventoryDevices`</b>:  List of InventoryDevice 
+
+---
+
+<a href="../../anta/inventory/__init__.py#L401"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>method</kbd> `AntaInventory.refresh_online_flag_inventory`
+
+```python
+refresh_online_flag_inventory() → None
+```
+
+refresh_online_flag_inventory Update is_online flag for all devices. 
+
+Execute in parallel a call to _refresh_online_flag_device to test device connectivity. 
 
 
 

--- a/docs/api/inventory.models.md
+++ b/docs/api/inventory.models.md
@@ -62,6 +62,29 @@ Inventory model exposed by Inventory class.
 
 
 
+---
+
+<a href="../../anta/inventory/models.py#L44"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>class</kbd> `InventoryDevices`
+Inventory model to list all InventoryDevice entries. 
+
+
+
+
+---
+
+<a href="../../anta/inventory/models.py#L48"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>method</kbd> `InventoryDevices.append`
+
+```python
+append(value) → None
+```
+
+Add support for append method. 
+
+
 
 
 ---

--- a/scripts/clear-counters.py
+++ b/scripts/clear-counters.py
@@ -4,10 +4,13 @@
 This script clear counters on devices
 """
 
+import logging
+import ssl
+import sys
 # standard imports
 from argparse import ArgumentParser
 from getpass import getpass
-import ssl
+
 from anta.inventory import AntaInventory
 
 # pylint: disable=protected-access
@@ -17,7 +20,7 @@ def clear_counters(inventory, enable_pass):
     """
     clear counters
     """
-    devices = inventory.inventory_get(established_only = True)
+    devices = inventory.get_inventory(established_only = True)
     for device in devices:
         switch = device.session
         response = switch.runCmds(1, ['show version'], 'json')
@@ -39,15 +42,17 @@ def report_uncleared_counters(inventory):
     """
     report unreachable devices
     """
-    devices = inventory.inventory_get(established_only = False)
+    devices = inventory.get_inventory(established_only = False)
     for device in devices:
         if device.established is False:
             print("Could not clear counters on device " + str(device.host))
 
 def main():
     """
-    test.
+    Main.
     """
+    logging.disable(sys.maxsize)
+
     parser = ArgumentParser(
         description='Clear counters on EOS devices'
         )
@@ -68,8 +73,13 @@ def main():
     args.password = getpass(prompt='Device password: ')
     args.enable_pass = getpass(prompt='Enable password (if any): ')
 
-    print('Password is: %s', str(args.password))
-    inventory = AntaInventory(inventory_file=args.file,username=args.username, password=args.password, auto_connect=True)
+    inventory = AntaInventory(
+        inventory_file=args.file,
+        username=args.username,
+        password=args.password,
+        auto_connect=True,
+        timeout=0.5
+    )
     clear_counters(inventory, args.enable_pass)
     report_uncleared_counters(inventory)
 

--- a/tests/units/inventory_test.py
+++ b/tests/units/inventory_test.py
@@ -208,7 +208,7 @@ class Test_AntaInventory():
             auto_connect=False
         )
         logging.info('Getting if %s from inventory', str(test_definition['parameters']['ipaddress_in_scope']))
-        device = inventory_test.device_get(host_ip= str(test_definition['parameters']['ipaddress_in_scope']))
+        device = inventory_test.get_device(host_ip= str(test_definition['parameters']['ipaddress_in_scope']))
         assert isinstance(device,InventoryDevice)
         assert str(device.host) == str(test_definition['parameters']['ipaddress_in_scope'])
 
@@ -247,6 +247,6 @@ class Test_AntaInventory():
             password='arista123',
             auto_connect=False
         )
-        inventory_json = json.loads(inventory_test.inventory_get(format_out='json', established_only=False))
+        inventory_json = json.loads(inventory_test.get_inventory(format_out='json', established_only=False))
         assert test_definition['parameters']['ipaddress_in_scope'] in [d['host'] for d in inventory_json]
         assert int(test_definition['parameters']['nb_hosts']) == len([d['host'] for d in inventory_json])


### PR DESCRIPTION
## Add native multiprocessing to discover devices part of inventory

- Check if devices are online using `multiprocessing` lib and set flag `is_online=True` per device
- Build session for devices with flag `is_online` set to True
- Expose with `get_inventory()` method

`is_online` flag is required since variables are not natively shared and the Server object cannot serialized as it contains an SSLS session.

## Other:

- Update name for methods
- Code re-ordering
- clear-counters script updated with new APIs and with logging disabled