### PR TITLE
feat(inventory): Add HW discovery mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 build
 dist
 *.egg-info
+scripts/test*.py

--- a/anta/inventory/models.py
+++ b/anta/inventory/models.py
@@ -39,6 +39,7 @@ class InventoryDevice(BaseModel):
     session: Any
     established = False
     is_online = False
+    hw_model: str = 'unset'
     url: str
 
 class InventoryDevices(BaseModel):

--- a/examples/inventory.yml
+++ b/examples/inventory.yml
@@ -7,9 +7,9 @@ anta_inventory:
   - host: 192.168.0.14
   - host: 192.168.0.15
   networks:
-  - network: 192.168.110.0/30
-  ranges:
-  - start: 10.0.0.9
-    end: 10.0.0.11
-  - start: 10.0.0.100
-    end: 10.0.0.101
+  - network: 192.168.110.0/24
+  # ranges:
+  # - start: 10.0.0.9
+  #   end: 10.0.0.11
+  # - start: 10.0.0.100
+  #   end: 10.0.0.101


### PR DESCRIPTION
- Add new key in InventoryDevice to report HW type.
- Add mechanism to automatically discover HW type when building eAPI session

```python
class InventoryDevice(BaseModel):
    """Inventory model exposed by Inventory class."""
    host: IPvAnyAddress
    username: str
    password: str
    session: Any
    established = False
    is_online = False
    hw_model: str = 'unset'
    url: str
```