### PR TITLE
make: add pre-commit hook for pylint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+---
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+- repo: local
+  hooks:
+    - id: pylint
+      name: pylint
+      entry: pylint
+      language: system
+      types: [python]
+      args:
+        [
+          "-rn", # Only display messages
+          "-sn", # Don't display the score
+          "--rcfile=pylintrc", # Link to your config file
+        ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,28 @@ python documentation/generate-functions-documentation.py
 ls docs/api
 ```
 
+## Git Pre-commit hook
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+When running a commit or a pre-commit check:
+
+```
+❯ echo "import foobaz" > test.py && git add test.py
+❯ pre-commit
+pylint...................................................................Failed
+- hook id: pylint
+- exit code: 22
+
+************* Module test
+test.py:1:0: C0114: Missing module docstring (missing-module-docstring)
+test.py:1:0: E0401: Unable to import 'foobaz' (import-error)
+test.py:1:0: W0611: Unused import foobaz (unused-import)
+```
+
 ## Continuous Integration
 
 GitHub actions is used to test git pushes and pull requests. The workflows are defined in this [directory](.github/workflows).

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ pytest-html>=3.1.1
 pytest-metadata>=1.11.0
 pytest-dependency
 yamllint
+pre-commit>=2.20.0


### PR DESCRIPTION
Add pre-commit hook to support pylint validation

## Test

```
❯ echo "import foobaz" > test.py && git add test.py
❯ pre-commit
pylint...................................................................Failed
- hook id: pylint
- exit code: 22

************* Module test
test.py:1:0: C0114: Missing module docstring (missing-module-docstring)
test.py:1:0: E0401: Unable to import 'foobaz' (import-error)
test.py:1:0: W0611: Unused import foobaz (unused-import)
```

## Installation

```
❯ pre-commit install
❯ pre-commit -h
usage: pre-commit [-h] [-V] {autoupdate,clean,gc,init-templatedir,install,install-hooks,migrate-config,run,sample-config,try-repo,uninstall,validate-config,validate-manifest,help,hook-impl} ...

positional arguments:
  {autoupdate,clean,gc,init-templatedir,install,install-hooks,migrate-config,run,sample-config,try-repo,uninstall,validate-config,validate-manifest,help,hook-impl}
    autoupdate          Auto-update pre-commit config to the latest repos' versions.
    clean               Clean out pre-commit files.
    gc                  Clean unused cached repos.
    init-templatedir    Install hook script in a directory intended for use with `git config init.templateDir`.
    install             Install the pre-commit script.
    install-hooks       Install hook environments for all environments in the config file. You may find `pre-commit install --install-hooks` more useful.
    migrate-config      Migrate list configuration to new map configuration.
    run                 Run hooks.
    sample-config       Produce a sample .pre-commit-config.yaml file
    try-repo            Try the hooks in a repository, useful for developing new hooks.
    uninstall           Uninstall the pre-commit script.
    validate-config     Validate .pre-commit-config.yaml files
    validate-manifest   Validate .pre-commit-hooks.yaml files
    help                Show help for a specific command.

optional arguments:
  -h, --help            show this help message and exit
  -V, --version         show program's version number and exit
```