### PR TITLE
feat(anta.reporter): Add skipped column in aggregated results

### DIFF
--- a/anta/reporter/__init__.py
+++ b/anta/reporter/__init__.py
@@ -150,7 +150,7 @@ class ReportTable():
         """
         # sourcery skip: class-extract-method
         table = Table(title=title)
-        headers = ['Test Case', '# of success', '# of failure', '# of errors', 'List of failed or error nodes']
+        headers = ['Test Case', '# of success', '# of skipped', '# of failure', '# of errors', 'List of failed or error nodes']
         table = self._build_headers(headers=headers, table=table)
         for testcase_read in result_manager.get_testcases():
             if testcase is None or str(testcase_read) == testcase:
@@ -163,9 +163,12 @@ class ReportTable():
                     str(result.host) for result in results if result.result in ['failure', 'error']]
                 nb_success = len(
                     [result for result in results if result.result == 'success'])
+                nb_skipped = len(
+                    [result for result in results if result.result == 'skipped'])
                 table.add_row(
                     testcase_read,
                     str(nb_success),
+                    str(nb_skipped),
                     str(nb_failure),
                     str(nb_error),
                     str(list_failure)
@@ -187,7 +190,7 @@ class ReportTable():
             Table: A fully populated rich Table
         """
         table = Table(title=title)
-        headers = ['Host IP', '# of success', '# of failure',
+        headers = ['Host IP', '# of success', '# of skipped', '# of failure',
                    '# of errors', 'List of failed ortest case']
         table = self._build_headers(headers=headers, table=table)
         for host_read in result_manager.get_hosts():
@@ -203,9 +206,12 @@ class ReportTable():
                     str(result.test) for result in results if result.result in ['failure', 'error']]
                 nb_success = len(
                     [result for result in results if result.result == 'success'])
+                nb_skipped = len(
+                    [result for result in results if result.result == 'skipped'])
                 table.add_row(
                     str(host_read),
                     str(nb_success),
+                    str(nb_skipped),
                     str(nb_failure),
                     str(nb_error),
                     str(list_failure)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,7 +12,7 @@ Have a quick look to the package documentation:
 
 Instantiate the class `Server` of `jsonrpclib` for an EOS device:
 
-```python
+```pythno
 >>> import ssl
 >>> from jsonrpclib import Server
 >>> ssl._create_default_https_context = ssl._create_unverified_context

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,7 +12,7 @@ Have a quick look to the package documentation:
 
 Instantiate the class `Server` of `jsonrpclib` for an EOS device:
 
-```pythno
+```python
 >>> import ssl
 >>> from jsonrpclib import Server
 >>> ssl._create_default_https_context = ssl._create_unverified_context


### PR DESCRIPTION
Add missing column to summary number of devices or tests skipped in aggregated
view.


```bash
$ python scripts/check-devices.py -i .personal/avd-lab.yml -c .personal/ceos-catalog.yml --table --by-test --test verify_mlag_status

                                              Summary per test case
┏━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Test Case          ┃ # of success ┃ # of skipped ┃ # of failure ┃ # of errors ┃ List of failed or error nodes ┃
┡━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ verify_mlag_status │ 8            │ 13           │ 0            │ 0           │ []                            │
└────────────────────┴──────────────┴──────────────┴──────────────┴─────────────┴───────────────────────────────┘
```

