### PR TITLE
feat(inventory): Add tag support to filter test execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,15 +73,21 @@ anta_inventory:
   hosts:
   - host: 192.168.0.10
   - host: 192.168.0.11
+    # Optional tag to assign to this device
+    tags: ['tag01', 'tag02']
   - host: 192.168.0.12
   - host: 192.168.0.13
   - host: 192.168.0.14
   - host: 192.168.0.15
   networks:
   - network: '192.168.110.0/24'
+    # Optional tag to assign to all devices in this subnet
+    tags: ['tag01', 'tag02']
   ranges:
   - start: 10.0.0.9
     end: 10.0.0.11
+    # Optional tag to assign to all devices in this range
+    tags: ['tag01', 'tag02']
   - start: 10.0.0.100
     end: 10.0.0.101
 ```
@@ -164,6 +170,7 @@ optional arguments:
                         eAPI connection timeout
   --hostip HOSTIP       search result for host
   --test TEST           search result for test
+  --tags TAGS           List of device tags to limit scope of testing
   --list                Display internal data
   --table               Result represented in tables
   --all-results         Display all test cases results. Default table view (Only valid with --table)

--- a/anta/inventory/models.py
+++ b/anta/inventory/models.py
@@ -7,6 +7,11 @@ from typing import List, Optional, Any, Iterator
 from pydantic import BaseModel, IPvAnyAddress, IPvAnyNetwork
 
 
+# Default values
+
+DEFAULT_TAG = 'default'
+DEFAULT_HW_MODEL = 'unset'
+
 # Pydantic models for input validation
 
 
@@ -19,6 +24,7 @@ class AntaInventoryHost(BaseModel):
     """
 
     host: IPvAnyAddress
+    tags: List[str] = [DEFAULT_TAG]
 
 
 class AntaInventoryNetwork(BaseModel):
@@ -30,6 +36,7 @@ class AntaInventoryNetwork(BaseModel):
     """
 
     network: IPvAnyNetwork
+    tags: List[str] = [DEFAULT_TAG]
 
 
 class AntaInventoryRange(BaseModel):
@@ -43,6 +50,7 @@ class AntaInventoryRange(BaseModel):
 
     start: IPvAnyAddress
     end: IPvAnyAddress
+    tags: List[str] = [DEFAULT_TAG]
 
 
 class AntaInventoryInput(BaseModel):
@@ -86,8 +94,9 @@ class InventoryDevice(BaseModel):
     session: Any
     established = False
     is_online = False
-    hw_model: str = "unset"
+    hw_model: str = DEFAULT_HW_MODEL
     url: str
+    tags: List[str] = [DEFAULT_TAG]
 
     def assert_enable_password_is_not_none(self, test_name: Optional[str] = None) -> None:
         """

--- a/anta/inventory/models.py
+++ b/anta/inventory/models.py
@@ -58,7 +58,7 @@ class AntaInventoryInput(BaseModel):
     User's inventory model.
 
     Attributes:
-        netwrks (List[AntaInventoryNetwork],Optional): List of AntaInventoryNetwork objects for networks.
+        networks (List[AntaInventoryNetwork],Optional): List of AntaInventoryNetwork objects for networks.
         hosts (List[AntaInventoryHost],Optional): List of AntaInventoryHost objects for hosts.
         range (List[AntaInventoryRange],Optional): List of AntaInventoryRange objects for ranges.
     """

--- a/scripts/check-devices.py
+++ b/scripts/check-devices.py
@@ -35,6 +35,7 @@ from rich.pretty import pprint
 
 import anta.loader
 from anta.inventory import AntaInventory
+from anta.inventory.models import DEFAULT_TAG
 from anta.result_manager import ResultManager
 from anta.reporter import ReportTable
 
@@ -96,6 +97,9 @@ def cli_manager() -> argparse.Namespace:
     parser.add_argument('--test', required=False,
                         default=None, help='search result for test')
 
+    parser.add_argument('--tags', required=False,
+                        default=DEFAULT_TAG, help='List of device tags to limit scope of testing')
+
     #############################
     # Display Options
 
@@ -138,6 +142,9 @@ if __name__ == '__main__':
         auto_connect=True
     )
 
+    scope_tags = cli_options.tags.split(',') if ',' in cli_options.tags else [
+        cli_options.tags]
+
     ############################################################################
     # Test loader
     ############################################################################
@@ -152,10 +159,10 @@ if __name__ == '__main__':
     # Test Execution
     ############################################################################
 
-    logger.info('starting running test on by_host ...')
+    logger.info('starting running test on inventory ...')
     manager = ResultManager()
     list_tests = []
-    for device, test in itertools.product(inventory_anta.get_inventory(), tests_catalog):
+    for device, test in itertools.product(inventory_anta.get_inventory(tags=scope_tags), tests_catalog):
         if ((cli_options.hostip is None or cli_options.hostip == str(device.host)) and
                 (cli_options.test is None or cli_options.test == str(test[0].__name__))):
             list_tests.append(str(test[0]))


### PR DESCRIPTION
Implement issue #44 

- feat(inventory): Add initial support for tags
- doc: Fix typo in docstring
- Update inventory module to support tag filtering in get_inventory
- Update check-devices.py to support tags

Inventory example:

```yaml
anta_inventory:
  hosts:
  - host: 192.168.0.10
    tags: ['test']
  - host: 192.168.0.11
    tags: ['dc1']
  - host: 192.168.0.12
    tags: ['dc1']
  - host: 192.168.0.13
    tags: ['dc2']
  - host: 192.168.0.14
  - host: 192.168.0.15
  - host: 10.73.252.11
    tags: ['dc1']
  ranges:
    - start: 10.73.252.12
      end: 10.73.252.50
      tags: ['clab']
```

Code execution

```bash
python scripts/check-devices.py -i .personal/avd-lab.yml -c .personal/ceos-catalog.yml --table --tags dc1
[08:07:43] INFO     Inventory .personal/avd-lab.yml loaded                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      check-devices.py
           INFO     starting running test on inventory ...                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      check-devices.p
[08:07:44] INFO     testing done !
                                                                                    All tests results
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Device IP    ┃ Test Name                         ┃ Test Status ┃ Message(s)                                                                                                            ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ 10.73.252.11 │ verify_eos_version                │ failure     │ device is running version 4.27.2F-26069621.4272F (engineering build) not in expected versions: ['4.25.4M', '4.26.1F'] │
│ 10.73.252.11 │ verify_field_notice_44_resolution │ skipped     │ verify_field_notice_44_resolution test is not supported on cEOSLab.                                                   │
│ 10.73.252.11 │ verify_uptime                     │ success     │                                                                                                                       │
│ 10.73.252.11 │ verify_zerotouch                  │ success     │                                                                                                                       │
│ 10.73.252.11 │ verify_running_config_diffs       │ success     │                                                                                                                       │
│ 10.73.252.11 │ verify_mlag_status                │ success     │                                                                                                                       │
│ 10.73.252.11 │ verify_mlag_interfaces            │ success     │                                                                                                                       │
│ 10.73.252.11 │ verify_mlag_config_sanity         │ success     │                                                                                                                       │
│ 10.73.252.11 │ verify_routing_protocol_model     │ success     │                                                                                                                       │
└──────────────┴───────────────────────────────────┴─────────────┴───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```