### PR TITLE
make: Prepare version management

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,20 @@
+[bumpversion]
+current_version = 0.3.0
+commit = True
+tag = True
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
+serialize =
+	{major}.{minor}.{patch}-{release}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:build]
+first_value = 1
+
+[bumpversion:file:anta/__init__.py]
+
+[bumpversion:part:release]
+optional_value = gamma
+values =
+	dev
+	beta
+	gamma

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ venv.bak/
 
 # mkdocs documentation
 /site
+
+# vscode settings
+.vscode/

--- a/anta/__init__.py
+++ b/anta/__init__.py
@@ -4,6 +4,19 @@
 anta init
 """
 
-__version__ = '0.1.0'
-__author__ = 'Khelil Sator'
-__author_email__ = 'ksator@arista.com'
+__version__ = "0.3.0"
+__author__ = "Khelil Sator"
+__email__ = "ksator@arista.com"
+__maintainer__ = "Khelil Sator"
+__credits__ = [
+    "Angélique Phillipps",
+    "Colin MacGiollaEáin",
+    "Khelil Sator",
+    "Matthieu Tache",
+    "Onur Gashi",
+    "Paul Lavelle",
+    "Guillaume Mulocher",
+    "Thomas Grimonet"
+]
+__copyright__ = "Copyright 2022, Arista EMEA AS"
+__license__ = "Apache"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-lazydocs
+bump2version==1.0.1
 pytest
 pylint
 pytest-cov>=2.11.1

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,9 @@ setup(
     install_requires=required,
     include_package_data=True,
     url="https://github.com/arista-netdevops-community/network-test-automation",
-    license="APACHE",
+    license=f"{anta.__license__.upper()}",
     author=f"{anta.__author__}",
-    author_email=f"{anta.__author_email__}",
+    author_email=f"{anta.__email__}",
     long_description=long_description,
     long_description_content_type='text/markdown',
     classifiers=[


### PR DESCRIPTION
## Description

- Align `ANTA` versin to 0.3.0 to prepare next release
- Implement initial [`bump2version`](https://github.com/c4urself/bump2version) configuration

## Example

```bash
# initial version: 0.2.0
❯ bump2version patch --allow-dirty
0.2.1-dev

❯ bump2version release --allow-dirty
0.2.1-beta

❯ bump2version release --allow-dirty
0.2.1
```