### PR TITLE
feat(anta.inventory): Add support for DNS names, eAPI port and device alias names

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,27 +1,47 @@
 {
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "check-devices debug",
-            "type": "python",
-            "request": "launch",
-            "program": "${workspaceFolder}/scripts/check-devices.py",
-            "args": [
-                "-u",
-                "admin",
-                "-p",
-                "admin123",
-                "-log",
-                "INFO",
-                "-i",
-                "${workspaceFolder}/.personal/avd-lab.yml",
-                "-c",
-                "${workspaceFolder}/.personal/ceos-catalog.yml",
-                "--table",
-                "--timeout",
-                "1"
-            ],
-            "console": "integratedTerminal"
-        }
-    ]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "check-devices debug",
+      "type": "python",
+      "request": "launch",
+      "program": "${workspaceFolder}/scripts/check-devices.py",
+      "args": [
+        "-u",
+        "admin",
+        "-p",
+        "admin123",
+        "-log",
+        "INFO",
+        "-i",
+        "${workspaceFolder}/.personal/avd-lab.yml",
+        "-c",
+        "${workspaceFolder}/.personal/ceos-catalog.yml",
+        "--table",
+        "--timeout",
+        "1"
+      ]
+    },
+    {
+      "name": "ANTA Tester",
+      "type": "python",
+      "request": "launch",
+      "program": "${workspaceFolder}/.github/scripts/anta-tester.py",
+      "args": [
+        "-u",
+        "admin",
+        "-p",
+        "admin",
+        "-e",
+        "admin",
+        "-l",
+        "--very-verbose",
+        "-i",
+        "${workspaceFolder}/.personal/inventory.yaml",
+        "-c",
+        "${workspaceFolder}/examples/tests_all.yaml"
+      ],
+      "console": "integratedTerminal"
+    }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+    "python.linting.enabled": true,
+    "python.linting.flake8Enabled": true,
+    "python.linting.flake8Args": [
+      "--config=/dev/null",
+      "--max-line-length=165"
+    ],
+    "python.linting.pylintEnabled": true,
+    "python.linting.pylintArgs": [
+      "--rcfile=pylintrc"
+    ],
+    "python.linting.mypyEnabled": true,
+    "python.linting.mypyArgs": [
+      "--config-file=pyproject.toml"
+    ],
+}

--- a/anta/decorators.py
+++ b/anta/decorators.py
@@ -71,7 +71,7 @@ def check_bgp_family_enable(family: str) -> Callable[..., Callable[..., TestResu
             eapi_command = "show bgp evpn summary" if family == "evpn" else eapi_command
             eapi_command = "show bgp rt-membership summary" if family == "rtc" else eapi_command
 
-            result = TestResult(host=str(device.host), test=function.__name__)  # type: ignore
+            result = TestResult(name=str(device.name), test=function.__name__)  # type: ignore
             try:
                 response = device.session.runCmds(  # type: ignore
                     1, [eapi_command], "json")  # type: ignore

--- a/anta/decorators.py
+++ b/anta/decorators.py
@@ -32,7 +32,7 @@ def skip_on_platforms(platforms: List[str]) -> Callable[..., Callable[..., TestR
             """
             device = args[0]
             if device.hw_model in platforms:  # type:ignore
-                result = TestResult(host=str(device.host), test=function.__name__)  # type: ignore
+                result = TestResult(name=device.name, test=function.__name__)  # type: ignore
                 result.is_skipped(
                     f"{wrapper.__name__} test is not supported on {device.hw_model}."  # type: ignore
                 )

--- a/anta/inventory/__init__.py
+++ b/anta/inventory/__init__.py
@@ -12,7 +12,6 @@ from socket import setdefaulttimeout
 from typing import List, Optional, Union, Any, Iterator
 
 import yaml
-from jinja2 import Template
 from jsonrpclib import Server
 from netaddr import IPAddress, IPNetwork
 from pydantic import ValidationError
@@ -99,8 +98,6 @@ class AntaInventory():
 
     # Root key of inventory part of the inventory file
     INVENTORY_ROOT_KEY = 'anta_inventory'
-    # Template to build eAPI connection URL
-    EAPI_SESSION_TPL = 'https://{{device_username}}:{{device_password}}@{{device}}/command-api'
     # Supported Output format
     INVENTORY_OUTPUT_FORMAT = ['native', 'json']
     # HW model definition in show version
@@ -155,7 +152,7 @@ class AntaInventory():
     # Boolean methods
     ###########################################################################
 
-    def _is_ip_exist(self, ip: str) -> bool:
+    def _is_ip_exist(self, ip: str) -> bool:  # TODO mtache: unused, remove this ?
         """Check if an IP is part of the current inventory.
 
         Args:
@@ -245,26 +242,6 @@ class AntaInventory():
         if device.is_online and hw_model:
             device.hw_model = hw_model
         return device
-
-    def _build_device_session_path(self, host: str, username: str, password: str) -> str:
-        """Construct URL to reach device using eAPI.
-
-        Jinja2 render to build URL to use for eAPI session.
-
-        Args:
-            host (str): IP Address of the device to target in the eAPI session
-            username (str): Username for authentication
-            password (str): Password for authentication
-
-        Returns:
-            str: String to use to create eAPI session
-        """
-        session_template = Template(self.EAPI_SESSION_TPL)
-        return session_template.render(
-            device=host,
-            device_username=username,
-            device_password=password
-        )
 
     def _build_device_session(self, device: InventoryDevice, timeout: float = 5) -> InventoryDevice:
         """Create eAPI RPC session to Arista EOS devices.
@@ -432,7 +409,7 @@ class AntaInventory():
 
         return inventory
 
-    def get_device(self, host_ip: str) -> Optional[InventoryDevice]:
+    def get_device(self, host_ip: str) -> Optional[InventoryDevice]:  # TODO mtache: unused, remove this ?
         """Get device information from a given IP.
 
         Args:
@@ -445,7 +422,7 @@ class AntaInventory():
             return [dev for dev in self._inventory if str(dev.host) == str(host_ip)][0]
         return None
 
-    def get_device_session(self, host_ip: str) -> Server:
+    def get_device_session(self, host_ip: str) -> Server:  # TODO mtache: unused, remove this ?
         """Expose RPC session of a given host from our inventory.
 
         Provide RPC session if the session exists, if not, it returns None

--- a/anta/inventory/__init__.py
+++ b/anta/inventory/__init__.py
@@ -533,4 +533,4 @@ class AntaInventory():
         with ThreadPoolExecutor() as executor:
             results_map = executor.map(
                 self._get_from_device,  self._inventory)
-            self._inventory = self._inventory_rebuild(results_map)
+        self._inventory = self._inventory_rebuild(results_map)

--- a/anta/inventory/__init__.py
+++ b/anta/inventory/__init__.py
@@ -9,7 +9,7 @@ import logging
 import ssl
 from concurrent.futures import ThreadPoolExecutor
 from socket import setdefaulttimeout
-from typing import List, Optional, Union, Any, Iterator
+from typing import List, Optional, Union, Iterator
 
 import yaml
 from jsonrpclib import Server
@@ -324,7 +324,7 @@ class AntaInventory():
                 self._add_device_to_inventory(str(range_increment), tags=range_def.tags)
                 range_increment += 1
 
-    def _inventory_rebuild(self, list_devices: Iterator[Any]) -> InventoryDevices:
+    def _inventory_rebuild(self, list_devices: Iterator[InventoryDevice]) -> InventoryDevices:
         """
         _inventory_rebuild Transform a list of InventoryDevice into a InventoryDevices object.
 

--- a/anta/inventory/__init__.py
+++ b/anta/inventory/__init__.py
@@ -467,8 +467,10 @@ class AntaInventory():
         """
         logger.debug(
             f"Searching for device {device.name} in {[ dev.name for dev in self._inventory]}")
-        device = [dev for dev in self._inventory if dev == device][0] or None
-        if device is None:
+        devices = [dev for dev in self._inventory if dev == device]
+        if len(devices) == 1:
+            device = devices[0]
+        else:
             return False
         logger.debug(f'Search result is: {device}')
         if device.is_online and not device.established:

--- a/anta/inventory/__init__.py
+++ b/anta/inventory/__init__.py
@@ -181,7 +181,7 @@ class AntaInventory():
         Returns:
             bool: True if device ready, False by default.
         """
-        logger.debug(f'Checking if device {device.host} is online')
+        logger.debug(f'Checking if device {device.name} is online')
         connection = Server(device.url)
         # Check connectivity
         setdefaulttimeout(timeout)
@@ -189,7 +189,7 @@ class AntaInventory():
             connection.runCmds(1, ['show version'])
         # pylint: disable=W0703
         except Exception as exp:
-            logger.warning(f'Service not running on device {device.host} with: f{exp}')
+            logger.warning(f'Service not running on device {device.name} with: f{exp}')
             return False
         else:
             return True
@@ -212,14 +212,14 @@ class AntaInventory():
         Returns:
             str: HW value read from the device using show version.
         """
-        logger.debug(f'Reading HW information for {device.host}')
+        logger.debug(f'Reading HW information for {device.name}')
         connection = Server(device.url)
         try:
             setdefaulttimeout(timeout)
             response = connection.runCmds(1, ['show version'])
         # pylint: disable=W0703
         except Exception:
-            logger.warning(f'Service not running on device {device.host}')
+            logger.warning(f'Service not running on device {device.name}')
             return None
         else:
             return response[0][self.HW_MODEL_KEY] if self.HW_MODEL_KEY in response[0] else None
@@ -238,7 +238,7 @@ class AntaInventory():
         Returns:
             InventoryDevice: Updated structure with devices information (is_online, HW model)
         """
-        logger.debug(f'Refreshing is_online flag for device {device.host}')
+        logger.debug(f'Refreshing is_online flag for device {device.name}')
         device.is_online = self._is_device_online(
             device=device, timeout=self.timeout)
         hw_model = self._read_device_hw(device=device, timeout=self.timeout)
@@ -283,37 +283,34 @@ class AntaInventory():
             connection.runCmds(1, ['show version'])
         # pylint: disable=W0703
         except Exception:
-            logger.warning(f'Service not running on device {device.host}')
+            logger.warning(f'Service not running on device {device.name}')
             device.session = None
         else:
             device.established = True
             device.session = connection
         return device
 
-    def _add_device_to_inventory(self, host_ip: str, tags: List[str] = None) -> None:
+    def _add_device_to_inventory(self, host: str, port: int = None, name: str = None, tags: List[str] = None) -> None:
         """Add a InventoryDevice to final inventory.
 
         Create InventoryDevice and append to existing inventory
 
         Args:
-            host_ip (str): IP address of the host
+            host (str): IP address or hostname of the device
+            port (int): eAPI port of the device
+            name (str): Optional name of the device
         """
-        assert self._username is not None
-        assert self._password is not None
 
         if tags is None:
             tags = [DEFAULT_TAG]
 
         device = InventoryDevice(
-            host=host_ip,
-            username=self._username,
+            name=name,
+            host=host,
+            port=port,
+            user=self._username,
             password=self._password,
             enable_password=self._enable_password,
-            url=self._build_device_session_path(
-                host=host_ip,
-                username=self._username,
-                password=self._password
-            ),
             tags=tags
         )
         self._inventory.append(device)
@@ -325,7 +322,7 @@ class AntaInventory():
         """
         assert self._read_inventory.hosts is not None
         for host in self._read_inventory.hosts:
-            self._add_device_to_inventory(host_ip=str(host.host), tags=host.tags)
+            self._add_device_to_inventory(host.host, host.port, host.name, tags=host.tags)
 
     def _inventory_read_networks(self) -> None:
         """Read input data from networks section and create inventory structure.
@@ -335,7 +332,7 @@ class AntaInventory():
         assert self._read_inventory.networks is not None
         for network in self._read_inventory.networks:
             for host_ip in IPNetwork(str(network.network)):
-                self._add_device_to_inventory(host_ip=host_ip, tags=network.tags)
+                self._add_device_to_inventory(host_ip, tags=network.tags)
 
     def _inventory_read_ranges(self) -> None:
         """Read input data from ranges section and create inventory structure.
@@ -347,8 +344,7 @@ class AntaInventory():
             range_increment = IPAddress(str(range_def.start))
             range_stop = IPAddress(str(range_def.end))
             while range_increment <= range_stop:
-                self._add_device_to_inventory(
-                    host_ip=str(range_increment), tags=range_def.tags)
+                self._add_device_to_inventory(str(range_increment), tags=range_def.tags)
                 range_increment += 1
 
     def _inventory_rebuild(self, list_devices: Iterator[Any]) -> InventoryDevices:
@@ -479,26 +475,27 @@ class AntaInventory():
             self.refresh_device_facts()
 
         for device in self._inventory:
-            self.create_device_session(host_ip=str(device.host))
+            self.create_device_session(device=device)
 
-    def create_device_session(self, host_ip: str) -> bool:
+    def create_device_session(self, device: InventoryDevice) -> bool:
         """Get session of a device.
 
         If device has already a session, function only returns active session, if not, try to build a new session
 
         Args:
-            host_ip (str): IP address of the device
+            device (InventoryDevice): Device object to use
 
         Returns:
             bool: True if update succeed, False if not
         """
-        logger.debug(f'Searching for device {host_ip} in {self._inventory}')
-        device = [dev for dev in self._inventory if str(dev.host) == host_ip][:1][0] or None
+        logger.debug(
+            f"Searching for device {device.name} in {[ dev.name for dev in self._inventory]}")
+        device = [dev for dev in self._inventory if dev == device][0] or None
         if device is None:
             return False
         logger.debug(f'Search result is: {device}')
-        if device.is_online and not device.established and self._is_ip_exist(host_ip):
-            logger.debug(f'Trying to connect to device {str(device.host)}')
+        if device.is_online and not device.established:
+            logger.debug(f'Trying to connect to device {str(device.name)}')
             device = self._build_device_session(
                 device=device, timeout=self.timeout)
             return True

--- a/anta/inventory/models.py
+++ b/anta/inventory/models.py
@@ -3,7 +3,9 @@
 
 """Models related to inventory management."""
 
-from typing import List, Optional, Any, Iterator
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Any, Iterator, Type
 from pydantic.networks import Parts
 from pydantic import BaseModel, IPvAnyAddress, IPvAnyNetwork, AnyHttpUrl, conint, root_validator
 
@@ -27,7 +29,7 @@ class AntaInventoryHost(BaseModel):
 
     name: Optional[str]
     host: str
-    port: Optional[conint(gt=1, lt=65535)]
+    port: Optional[conint(gt=1, lt=65535)]  # type: ignore
     tags: List[str] = [DEFAULT_TAG]
 
 
@@ -95,7 +97,7 @@ class eAPIUrl(AnyHttpUrl):
     host_required = True
 
     @staticmethod
-    def get_default_parts(parts: 'Parts') -> 'Parts':
+    def get_default_parts(parts: Parts) -> Parts:
         return {
             'scheme': 'http' if ((parts.get('port') in ['80', '8080']) or parts.get('host') is None) else 'https',
             'domain': 'localhost' if (parts.get('port') == '8080') else '',
@@ -104,7 +106,7 @@ class eAPIUrl(AnyHttpUrl):
         }
 
     @classmethod
-    def build(cls, **kwargs):
+    def build(cls: Type[eAPIUrl], **kwargs: Any) -> eAPIUrl:
         """
         Include default path and port when building an eAPI URL
         """
@@ -145,15 +147,15 @@ class InventoryDevice(BaseModel):
     tags: List[str] = [DEFAULT_TAG]
 
     @root_validator(pre=True)
-    def build_name(cls, values):
+    def build_name(cls: Type[InventoryDevice], values: Dict[str, Any]) -> Dict[str, Any]:
         """ Build name attribute """
         if values.get('name') is None:
             assert 'host' in values, 'host required if name is not provided'
-            values['name'] = f"{values.get('host')}:{values.get('url').get('port')}"
+            values['name'] = f"{values.get('host')}:{values['url'].get('port')}"
         return values
 
     @root_validator(pre=True)
-    def build_eapi_url(cls, values):
+    def build_eapi_url(cls: Type[InventoryDevice], values: Dict[str, Any]) -> Dict[str, Any]:
         """ Build url attribute """
         if values.get('url') is None:
             if values.get('host') is not None:
@@ -165,7 +167,7 @@ class InventoryDevice(BaseModel):
             values['url'] = eAPIUrl.build(**values)
         return values
 
-    def __eq__(self, other):
+    def __eq__(self, other: BaseModel) -> bool:
         """
             Two InventoryDevice objects are equal if the hostname and the port are the same.
             This covers the use case of port forwarding when the host is localhost and the devices have different ports.

--- a/anta/inventory/models.py
+++ b/anta/inventory/models.py
@@ -73,6 +73,45 @@ class AntaInventoryInput(BaseModel):
 
 # Pydantic models for inventory output structures
 
+class eAPIUrl(AnyHttpUrl):
+    """
+    eAPI URL field type
+    The build method has been overriden to provide default value of a eAPI endpoint when using it.
+
+    Examples:
+    In : eAPIUrl.build()
+    Out: 'http://localhost:8080/command-api'
+
+    In : eAPIUrl.build(host='1.1.1.1')
+    Out: 'https://1.1.1.1:443/command-api'
+
+    In : eAPIUrl.build(host='1.1.1.1', port='80')
+    Out: 'http://1.1.1.1:80/command-api'
+    """
+    allowed_schemes = {'http', 'https'}
+    host_required = True
+
+    @staticmethod
+    def get_default_parts(parts: 'Parts') -> 'Parts':
+        return {
+            'scheme': 'http' if ((parts.get('port') in ['80', '8080']) or parts.get('host') is None) else 'https',
+            'domain': 'localhost' if (parts.get('port') == '8080') else '',
+            'port': '8080' if (parts.get('host') is None) else '443',
+            'path': '/command-api',
+        }
+
+    @classmethod
+    def build(cls, **kwargs):
+        """
+        Include default path and port when building an eAPI URL
+        """
+        parts = Parts(**kwargs)
+        default = cls.get_default_parts(parts)
+        for field in default:
+            if field not in kwargs:
+                kwargs.update({field: default.get(field)})
+        return super().build(**kwargs)
+
 
 class InventoryDevice(BaseModel):
     """

--- a/anta/result_manager/models.py
+++ b/anta/result_manager/models.py
@@ -4,7 +4,7 @@
 """Models related to anta.result_manager module."""
 
 from typing import List, Iterator
-from pydantic import BaseModel, IPvAnyAddress, validator
+from pydantic import BaseModel, validator
 
 RESULT_OPTIONS = ['unset', 'success', 'failure', 'error', 'skipped']
 
@@ -14,12 +14,12 @@ class TestResult(BaseModel):
     Describe result of a test from a single device.
 
     Attributes:
-        host (IPvAnyAddress): IPv4 or IPv6 address of the device where the test has run.
+        name (str): Device name where the test has run.
         test (str): Test name runs on the device.
         results (str): Result of the test. Can be one of unset / failure / success.
         message (str, optional): Message to report after the test.
     """
-    host: IPvAnyAddress
+    name: str
     test: str
     result: str = 'unset'
     messages: List[str] = []

--- a/anta/tests/configuration.py
+++ b/anta/tests/configuration.py
@@ -28,8 +28,8 @@ def verify_zerotouch(device: InventoryDevice) -> TestResult:
 
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
     try:
         response = device.session.runCmds(1, ["show zerotouch"], "json")
         logger.debug(f'query result is: {response}')
@@ -41,7 +41,7 @@ def verify_zerotouch(device: InventoryDevice) -> TestResult:
 
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f'exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}')
+            f'exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}')
         result.is_error(str(e))
 
     return result
@@ -64,8 +64,8 @@ def verify_running_config_diffs(device: InventoryDevice) -> TestResult:
 
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
     try:
         device.assert_enable_password_is_not_none("verify_running_config_diffs")
 
@@ -89,7 +89,7 @@ def verify_running_config_diffs(device: InventoryDevice) -> TestResult:
 
     except (ValueError, jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f'exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}')
+            f'exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}')
         result.is_error(str(e))
 
     return result

--- a/anta/tests/hardware.py
+++ b/anta/tests/hardware.py
@@ -36,8 +36,8 @@ def verify_transceivers_manufacturers(
     """
 
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
     if not manufacturers:
         result.is_skipped(
             "verify_transceivers_manufacturers was not run as no "
@@ -63,7 +63,7 @@ def verify_transceivers_manufacturers(
 
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f"exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}"
+            f"exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}"
         )
         result.is_error(str(e))
 
@@ -89,8 +89,8 @@ def verify_system_temperature(device: InventoryDevice) -> TestResult:
 
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
 
     try:
         response = device.session.runCmds(
@@ -107,7 +107,7 @@ def verify_system_temperature(device: InventoryDevice) -> TestResult:
 
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f"exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}"
+            f"exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}"
         )
         result.is_error(str(e))
 
@@ -134,8 +134,8 @@ def verify_transceiver_temperature(device: InventoryDevice) -> TestResult:
 
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
 
     try:
         response = device.session.runCmds(
@@ -164,7 +164,7 @@ def verify_transceiver_temperature(device: InventoryDevice) -> TestResult:
 
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f"exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}"
+            f"exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}"
         )
         result.is_error(str(e))
 
@@ -189,8 +189,8 @@ def verify_environment_cooling(device: InventoryDevice) -> TestResult:
 
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
 
     try:
         response = device.session.runCmds(
@@ -207,7 +207,7 @@ def verify_environment_cooling(device: InventoryDevice) -> TestResult:
 
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f"exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}"
+            f"exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}"
         )
         result.is_error(str(e))
 
@@ -232,8 +232,8 @@ def verify_environment_power(device: InventoryDevice) -> TestResult:
 
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
 
     try:
         response = device.session.runCmds(1, ["show system environment power"], "json")
@@ -252,7 +252,7 @@ def verify_environment_power(device: InventoryDevice) -> TestResult:
 
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f"exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}"
+            f"exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}"
         )
         result.is_error(str(e))
 
@@ -277,8 +277,8 @@ def verify_adverse_drops(device: InventoryDevice) -> TestResult:
 
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
 
     try:
         response = device.session.runCmds(1, ["show hardware counter drop"], "json")
@@ -293,7 +293,7 @@ def verify_adverse_drops(device: InventoryDevice) -> TestResult:
 
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f"exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}"
+            f"exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}"
         )
         result.is_error(str(e))
 

--- a/anta/tests/interfaces.py
+++ b/anta/tests/interfaces.py
@@ -25,7 +25,7 @@ def verify_interface_utilization(device: InventoryDevice) -> TestResult:
         * result = "error" if any exception is caught
 
     """
-    result = TestResult(host=str(device.host), test="verify_interface_utilization")
+    result = TestResult(name=device.name, test="verify_interface_utilization")
     try:
         # TODO make it JSON - bad news it seems percentages are not in the json payload
         response = device.session.runCmds(1, ["show interfaces counters rates"], "text")
@@ -69,7 +69,7 @@ def verify_interface_errors(device: InventoryDevice) -> TestResult:
         * result = "error" if any exception is caught
 
     """
-    result = TestResult(host=str(device.host), test="verify_interface_errors")
+    result = TestResult(name=device.name, test="verify_interface_errors")
 
     try:
         response = device.session.runCmds(
@@ -109,7 +109,7 @@ def verify_interface_discards(device: InventoryDevice) -> TestResult:
         * result = "error" if any exception is caught
 
     """
-    result = TestResult(host=str(device.host), test="verify_interface_discards")
+    result = TestResult(name=device.name, test="verify_interface_discards")
 
     try:
         response = device.session.runCmds(
@@ -149,7 +149,7 @@ def verify_interface_errdisabled(device: InventoryDevice) -> TestResult:
         * result = "error" if any exception is caught
 
     """
-    result = TestResult(host=str(device.host), test="verify_interface_errdisabled")
+    result = TestResult(name=device.name, test="verify_interface_errdisabled")
 
     try:
         response = device.session.runCmds(1, ["show interfaces status"], "json")
@@ -192,7 +192,7 @@ def verify_interfaces_status(
         * result = "error" if any exception is caught
 
     """
-    result = TestResult(host=str(device.host), test="verify_interfaces_status")
+    result = TestResult(name=device.name, test="verify_interfaces_status")
     if not minimum:
         result.result = "skipped"
         result.messages.append(
@@ -247,7 +247,7 @@ def verify_storm_control_drops(device: InventoryDevice) -> TestResult:
         * result = "error" if any exception is caught
 
     """
-    result = TestResult(host=str(device.host), test="verify_storm_control_drops")
+    result = TestResult(name=device.name, test="verify_storm_control_drops")
 
     try:
         response = device.session.runCmds(1, ["show storm-control"], "json")
@@ -293,7 +293,7 @@ def verify_portchannels(device: InventoryDevice) -> TestResult:
         * result = "error" if any exception is caught
 
     """
-    result = TestResult(host=str(device.host), test="verify_portchannels")
+    result = TestResult(name=device.name, test="verify_portchannels")
 
     try:
         response = device.session.runCmds(1, ["show port-channel"], "json")
@@ -334,7 +334,7 @@ def verify_illegal_lacp(device: InventoryDevice) -> TestResult:
         * result = "error" if any exception is caught
 
     """
-    result = TestResult(host=str(device.host), test="verify_illegal_lacp")
+    result = TestResult(name=device.name, test="verify_illegal_lacp")
 
     try:
         response = device.session.runCmds(1, ["show lacp counters all-ports"], "json")
@@ -380,7 +380,7 @@ def verify_loopback_count(device: InventoryDevice, number: int = None) -> TestRe
         * result = "error" if any exception is caught
 
     """
-    result = TestResult(host=str(device.host), test="verify_loopback_count")
+    result = TestResult(name=device.name, test="verify_loopback_count")
 
     if not number:
         result.is_skipped(
@@ -438,7 +438,7 @@ def verify_svi(device: InventoryDevice) -> TestResult:
         * result = "error" if any exception is caught
 
     """
-    result = TestResult(host=str(device.host), test="verify_svi")
+    result = TestResult(name=device.name, test="verify_svi")
 
     try:
         response = device.session.runCmds(1, ["show ip interface brief"], "json")
@@ -482,7 +482,7 @@ def verify_spanning_tree_blocked_ports(device: InventoryDevice) -> TestResult:
 
     """
     result = TestResult(
-        host=str(device.host), test="verify_spanning_tree_blocked_ports"
+        name=str(device.name), test="verify_spanning_tree_blocked_ports"
     )
 
     try:

--- a/anta/tests/interfaces.py
+++ b/anta/tests/interfaces.py
@@ -77,8 +77,8 @@ def verify_interface_errors(device: InventoryDevice) -> TestResult:
         )
 
         wrong_interfaces = {
-            interface: {counter: value for counter, value in outer_v.items if value > 0}
-            for interface, outer_v in response[0]["interfaceErrorCounters"]
+            interface: {counter: value for counter, value in outer_v.items() if value > 0}
+            for interface, outer_v in response[0]["interfaceErrorCounters"].items()
         }
         if len(wrong_interfaces) == 0:
             result.is_success()
@@ -117,8 +117,8 @@ def verify_interface_discards(device: InventoryDevice) -> TestResult:
         )
 
         wrong_interfaces = {
-            interface: {counter: value for counter, value in outer_v.items if value > 0}
-            for interface, outer_v in response[0]["interfaces"]
+            interface: {counter: value for counter, value in outer_v.items() if value > 0}
+            for interface, outer_v in response[0]["interfaces"].items()
         }
         if len(wrong_interfaces) == 0:
             result.is_success()

--- a/anta/tests/mlag.py
+++ b/anta/tests/mlag.py
@@ -29,8 +29,8 @@ def verify_mlag_status(device: InventoryDevice) -> TestResult:
 
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
 
     try:
         response = device.session.runCmds(1, ["show mlag"], "json")
@@ -49,7 +49,7 @@ def verify_mlag_status(device: InventoryDevice) -> TestResult:
 
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f'exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}')
+            f'exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}')
 
         result.is_error(str(e))
     return result
@@ -71,8 +71,8 @@ def verify_mlag_interfaces(device: InventoryDevice) -> TestResult:
 
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
 
     try:
         response = device.session.runCmds(1, ["show mlag"], "json")
@@ -89,7 +89,7 @@ def verify_mlag_interfaces(device: InventoryDevice) -> TestResult:
 
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f'exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}')
+            f'exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}')
 
         result.is_error(str(e))
     return result
@@ -111,8 +111,8 @@ def verify_mlag_config_sanity(device: InventoryDevice) -> TestResult:
 
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
 
     try:
         response = device.session.runCmds(1, ["show mlag config-sanity"], "json")
@@ -142,7 +142,7 @@ def verify_mlag_config_sanity(device: InventoryDevice) -> TestResult:
 
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f'exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}')
+            f'exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}')
 
         result.is_error(str(e))
     return result

--- a/anta/tests/multicast.py
+++ b/anta/tests/multicast.py
@@ -33,8 +33,8 @@ def verify_igmp_snooping_vlans(
 
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
 
     if not vlans or not configuration:
         result.result = "skipped"
@@ -60,7 +60,7 @@ def verify_igmp_snooping_vlans(
 
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f"exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}"
+            f"exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}"
         )
         result.is_error(str(e))
 
@@ -86,8 +86,8 @@ def verify_igmp_snooping_global(
         * result = "error" if any exception is caught
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
 
     if not configuration:
         result.is_skipped(
@@ -106,7 +106,7 @@ def verify_igmp_snooping_global(
 
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f"exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}"
+            f"exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}"
         )
         result.is_error(str(e))
 

--- a/anta/tests/profiles.py
+++ b/anta/tests/profiles.py
@@ -34,8 +34,8 @@ def verify_unified_forwarding_table_mode(
         * result = "error" if any exception is caught
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
     if not mode:
         result.is_skipped(
             "verify_unified_forwarding_table_mode was not run as no mode was given"
@@ -55,7 +55,7 @@ def verify_unified_forwarding_table_mode(
             )
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f'exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}')
+            f'exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}')
         result.is_error(str(e))
     return result
 
@@ -79,8 +79,8 @@ def verify_tcam_profile(device: InventoryDevice, profile: str) -> TestResult:
         * result = "error" if any exception is caught
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
     if not profile:
         result.is_skipped("verify_tcam_profile was not run as no profile was given")
         return result
@@ -98,6 +98,6 @@ def verify_tcam_profile(device: InventoryDevice, profile: str) -> TestResult:
             )
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f'exception raised for {inspect.stack()[0][3]} -  {device.host}: {e.__class__.__name__} - {str(e)}')
+            f'exception raised for {inspect.stack()[0][3]} -  {device.name}: {e.__class__.__name__} - {str(e)}')
         result.is_error(str(e))
     return result

--- a/anta/tests/routing/bgp.py
+++ b/anta/tests/routing/bgp.py
@@ -33,8 +33,8 @@ def verify_bgp_ipv4_unicast_state(device: InventoryDevice) -> TestResult:
         * result = "error" if any exception is caught
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
 
     try:
         response = device.session.runCmds(
@@ -73,7 +73,7 @@ def verify_bgp_ipv4_unicast_state(device: InventoryDevice) -> TestResult:
             result.is_failure(f"Some IPv4 Unicast BGP Peer are not up: {state_issue}")
 
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
-        logger.error(f'exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}')
+        logger.error(f'exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}')
 
         result.is_error(str(e))
     return result
@@ -104,8 +104,8 @@ def verify_bgp_ipv4_unicast_count(
         * result = "error" if any exception is caught
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
 
     if not number or not vrf:
         result.is_skipped(
@@ -147,7 +147,7 @@ def verify_bgp_ipv4_unicast_count(
 
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f'exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}')
+            f'exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}')
         result.is_error(str(e))
     return result
 
@@ -171,8 +171,8 @@ def verify_bgp_ipv6_unicast_state(device: InventoryDevice) -> TestResult:
         * result = "error" if any exception is caught
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
 
     try:
         response = device.session.runCmds(
@@ -212,7 +212,7 @@ def verify_bgp_ipv6_unicast_state(device: InventoryDevice) -> TestResult:
 
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f'exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}')
+            f'exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}')
         result.is_error(str(e))
     return result
 
@@ -236,8 +236,8 @@ def verify_bgp_evpn_state(device: InventoryDevice) -> TestResult:
 
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
 
     try:
         response = device.session.runCmds(1, ["show bgp evpn summary"], "json")
@@ -259,7 +259,7 @@ def verify_bgp_evpn_state(device: InventoryDevice) -> TestResult:
 
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f'exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}')
+            f'exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}')
         result.is_error(str(e))
     return result
 
@@ -285,8 +285,8 @@ def verify_bgp_evpn_count(device: InventoryDevice, number: int) -> TestResult:
 
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
 
     if not number:
         result.is_skipped(
@@ -310,7 +310,7 @@ def verify_bgp_evpn_count(device: InventoryDevice, number: int) -> TestResult:
                 )
 
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
-        logger.error(f'exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}')
+        logger.error(f'exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}')
 
         result.is_error(str(e))
     return result
@@ -334,8 +334,8 @@ def verify_bgp_rtc_state(device: InventoryDevice) -> TestResult:
 
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
 
     try:
         response = device.session.runCmds(1, ["show bgp rt-membership summary"], "json")
@@ -355,7 +355,7 @@ def verify_bgp_rtc_state(device: InventoryDevice) -> TestResult:
 
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f'exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}')
+            f'exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}')
         result.is_error(str(e))
     return result
 
@@ -381,8 +381,8 @@ def verify_bgp_rtc_count(device: InventoryDevice, number: int) -> TestResult:
 
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
 
     if not number:
         result.is_skipped(
@@ -410,6 +410,6 @@ def verify_bgp_rtc_count(device: InventoryDevice, number: int) -> TestResult:
 
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f'exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}')
+            f'exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}')
         result.is_error(str(e))
     return result

--- a/anta/tests/routing/generic.py
+++ b/anta/tests/routing/generic.py
@@ -33,8 +33,8 @@ def verify_routing_protocol_model(
         * result = "error" if any exception is caught
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
 
     if not model:
         result.is_skipped(
@@ -57,7 +57,7 @@ def verify_routing_protocol_model(
             )
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f'exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}')
+            f'exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}')
 
         result.is_error(str(e))
     return result
@@ -84,8 +84,8 @@ def verify_routing_table_size(
         * result = "error" if any exception is caught
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
 
     if not minimum or not maximum:
         result.is_skipped(
@@ -107,7 +107,7 @@ def verify_routing_table_size(
             )
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f'exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}')
+            f'exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}')
 
         result.is_error(str(e))
     return result
@@ -128,8 +128,8 @@ def verify_bfd(device: InventoryDevice) -> TestResult:
         * result = "error" if any exception is caught
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
 
     try:
         response = device.session.runCmds(1, ["show bfd peers"], "json")
@@ -160,7 +160,7 @@ def verify_bfd(device: InventoryDevice) -> TestResult:
             result.is_success()
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f'exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}')
+            f'exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}')
 
         result.is_error(str(e))
     return result

--- a/anta/tests/routing/ospf.py
+++ b/anta/tests/routing/ospf.py
@@ -27,8 +27,8 @@ def verify_ospf_state(device: InventoryDevice) -> TestResult:
         * result = "error" if any exception is caught
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
     try:
         response = device.session.runCmds(
             1, ["show ip ospf neighbor | exclude FULL|Address"], "text"
@@ -43,7 +43,7 @@ def verify_ospf_state(device: InventoryDevice) -> TestResult:
             result.is_failure("Some neighbors are not correctly configured.")
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f'exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}')
+            f'exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}')
 
         result.is_error(str(e))
     return result
@@ -66,8 +66,8 @@ def verify_ospf_count(device: InventoryDevice, number: int) -> TestResult:
         * result = "error" if any exception is caught
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
     if not number:
         result.is_skipped(
             "verify_igmp_snooping_vlans was not run as no number was given"
@@ -90,7 +90,7 @@ def verify_ospf_count(device: InventoryDevice, number: int) -> TestResult:
             )
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f'exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}')
+            f'exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}')
 
         result.is_error(str(e))
     return result

--- a/anta/tests/software.py
+++ b/anta/tests/software.py
@@ -34,8 +34,8 @@ def verify_eos_version(
 
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
     if not versions:
         result.is_skipped("verify_eos_version was not run as no versions were given")
         return result
@@ -52,7 +52,7 @@ def verify_eos_version(
             )
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f"exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}"
+            f"exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}"
         )
         result.is_error(str(e))
     return result
@@ -78,8 +78,8 @@ def verify_terminattr_version(
 
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
     if not versions:
         result.is_skipped(
             "verify_terminattr_version was not run as no versions were given"
@@ -98,7 +98,7 @@ def verify_terminattr_version(
             )
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f"exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}"
+            f"exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}"
         )
         result.is_error(str(e))
     return result
@@ -120,8 +120,8 @@ def verify_eos_extensions(device: InventoryDevice) -> TestResult:
 
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
     try:
         response = device.session.runCmds(
             1, ["show extensions", "show boot-extensions"], "json"
@@ -149,7 +149,7 @@ def verify_eos_extensions(device: InventoryDevice) -> TestResult:
             )
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f"exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}"
+            f"exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}"
         )
         result.is_error(str(e))
     return result
@@ -174,8 +174,8 @@ def verify_field_notice_44_resolution(device: InventoryDevice) -> TestResult:
         * result = "error" if any exception is caught
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
 
     try:
         response = device.session.runCmds(1, ["show version detail"], "json")

--- a/anta/tests/system.py
+++ b/anta/tests/system.py
@@ -29,8 +29,8 @@ def verify_uptime(device: InventoryDevice, minimum: int = None) -> TestResult:
 
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
     if not minimum:
         result.is_skipped("verify_uptime was not run as no minimum were given")
         return result
@@ -44,7 +44,7 @@ def verify_uptime(device: InventoryDevice, minimum: int = None) -> TestResult:
             result.is_failure(f"Uptime is {response_data}")
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f'exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}')
+            f'exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}')
         result.is_error(str(e))
     return result
 
@@ -69,8 +69,8 @@ def verify_reload_cause(device: InventoryDevice) -> TestResult:
 
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
     try:
         response = device.session.runCmds(
             1, ["show reload cause"], "json"
@@ -90,7 +90,7 @@ def verify_reload_cause(device: InventoryDevice) -> TestResult:
             result.is_failure(f"Reload cause is {response_data}")
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f'exception raised for {inspect.stack()[0][3]} -  {device.host}: {e.__class__.__name__} - {str(e)}')
+            f'exception raised for {inspect.stack()[0][3]} -  {device.name}: {e.__class__.__name__} - {str(e)}')
         result.is_error(str(e))
     return result
 
@@ -111,8 +111,8 @@ def verify_coredump(device: InventoryDevice) -> TestResult:
 
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
     try:
         device.assert_enable_password_is_not_none("verify_coredump")
 
@@ -152,8 +152,8 @@ def verify_agent_logs(device: InventoryDevice) -> TestResult:
 
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
     try:
         response = device.session.runCmds(1, ["show agent logs crash"], "text")
         logger.debug(f'query result is: {response}')
@@ -164,7 +164,7 @@ def verify_agent_logs(device: InventoryDevice) -> TestResult:
             result.is_failure(f"device reported some agent crashes: {response_data}")
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f'exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}')
+            f'exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}')
         result.is_error(str(e))
     return result
 
@@ -185,8 +185,8 @@ def verify_syslog(device: InventoryDevice) -> TestResult:
         * result = "error" if any exception is caught
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
     try:
         response = device.session.runCmds(
             1, ["show logging last 7 days threshold warnings"], "text"
@@ -201,7 +201,7 @@ def verify_syslog(device: InventoryDevice) -> TestResult:
             )
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f'exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}')
+            f'exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}')
         result.is_error(str(e))
     return result
 
@@ -221,8 +221,8 @@ def verify_cpu_utilization(device: InventoryDevice) -> TestResult:
         * result = "error" if any exception is caught
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
     try:
         response = device.session.runCmds(1, ["show processes top once"], "json")
         logger.debug(f'query result is: {response}')
@@ -235,7 +235,7 @@ def verify_cpu_utilization(device: InventoryDevice) -> TestResult:
             )
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f'exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}')
+            f'exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}')
         result.is_error(str(e))
     return result
 
@@ -255,8 +255,8 @@ def verify_memory_utilization(device: InventoryDevice) -> TestResult:
         * result = "error" if any exception is caught
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
     try:
         response = device.session.runCmds(1, ["show version"], "json")
         logger.debug(f'query result is: {response}')
@@ -268,7 +268,7 @@ def verify_memory_utilization(device: InventoryDevice) -> TestResult:
             result.is_failure(f"device report a high memory usage: {memory_usage*100}%")
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f'exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}')
+            f'exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}')
         result.is_error(str(e))
     return result
 
@@ -289,8 +289,8 @@ def verify_filesystem_utilization(device: InventoryDevice) -> TestResult:
         * result = "error" if any exception is caught
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
     try:
         response = device.session.runCmds(
             1,
@@ -308,7 +308,7 @@ def verify_filesystem_utilization(device: InventoryDevice) -> TestResult:
                     f'mount point {line} is higher than 75% (reprted {int(line.split()[4].replace(" % ", ""))})'
                 )
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
-        logger.error(f'exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}')
+        logger.error(f'exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}')
 
         result.is_error(str(e))
     return result
@@ -330,8 +330,8 @@ def verify_ntp(device: InventoryDevice) -> TestResult:
         * result = "error" if any exception is caught
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
     try:
         response = device.session.runCmds(1, ["show ntp status"], "text")
         logger.debug(f'query result is: {response}')
@@ -342,6 +342,6 @@ def verify_ntp(device: InventoryDevice) -> TestResult:
             result.is_failure(f"not sync with NTP server ({data})")
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f'exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}')
+            f'exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}')
         result.is_error(str(e))
     return result

--- a/anta/tests/vxlan.py
+++ b/anta/tests/vxlan.py
@@ -28,8 +28,8 @@ def verify_vxlan(device: InventoryDevice) -> TestResult:
 
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
 
     try:
         response = device.session.runCmds(1, ["show interfaces description"], "json")
@@ -51,7 +51,7 @@ def verify_vxlan(device: InventoryDevice) -> TestResult:
 
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f"exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}"
+            f"exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}"
         )
         result.is_error(str(e))
 
@@ -73,8 +73,8 @@ def verify_vxlan_config_sanity(device: InventoryDevice) -> TestResult:
         * result = "error" if any exception is caught
     """
     function_name = inspect.stack()[0][3]
-    logger.debug(f"Start {function_name} check for host {device.host}")
-    result = TestResult(host=str(device.host), test=function_name)
+    logger.debug(f"Start {function_name} check for host {device.name}")
+    result = TestResult(name=device.name, test=function_name)
 
     try:
         response = device.session.runCmds(1, ["show vxlan config-sanity"], "json")
@@ -100,7 +100,7 @@ def verify_vxlan_config_sanity(device: InventoryDevice) -> TestResult:
 
     except (jsonrpc.AppError, KeyError, socket.timeout) as e:
         logger.error(
-            f"exception raised for {inspect.stack()[0][3]} -  {device.host}: {str(e)}"
+            f"exception raised for {inspect.stack()[0][3]} -  {device.name}: {str(e)}"
         )
         result.is_error(str(e))
 


### PR DESCRIPTION
When using a containerlab topology on macOS, we need to use port forwarding to localhost to access eAPI endpoints.
The current inventory only supports IP addresses. The PR is to support hostnames (DNS names instead of IP), ports and alias names in the inventory.

The following inventory works with this PR:
```
anta_inventory:
  hosts:
  - name: spine1
    host: localhost
    port: 44301
  - name: spine2
    host: localhost
    port: 44302
  - name: leaf1
    host: localhost
    port: 44311
  - name: leaf1
    host: localhost
    port: 44312
  - name: leaf3
    host: localhost
    port: 44313
  - name: leaf4
    host: localhost
    port: 44314
```