### PR TITLE
feat(anta.inventory): use aioeapi to handle a device session 

### DIFF
--- a/.github/scripts/anta-tester.py
+++ b/.github/scripts/anta-tester.py
@@ -59,7 +59,7 @@ logging.getLogger('anta.tests.routing.generic').setLevel(logging.ERROR)
 logging.getLogger('anta.tests.routing.bgp').setLevel(logging.ERROR)
 logging.getLogger('anta.tests.routing.ospf').setLevel(logging.ERROR)
 
-async def main(inventory_anta: AntaInventory, tests_catalog: List[Tuple[Callable[..., TestResult], Dict[Any, Any]]]):
+async def main(inventory_anta: AntaInventory, tests_catalog: List[Tuple[Callable[..., TestResult], Dict[Any, Any]]]) -> None:
     await inventory_anta.connect_inventory()
     return await run_tests(inventory_anta, tests_catalog)
 
@@ -69,7 +69,7 @@ async def run_tests(inventory_anta: AntaInventory, tests_catalog: List[Tuple[Cal
     """
     manager = ResultManager()
     tests = itertools.product(inventory_anta.get_inventory(), tests_catalog)
-    results = await asyncio.gather(*(test[0](device, **test[1]) for device, test in tests), return_exceptions=False)
+    results = await asyncio.gather(*(test[0](device, **test[1]) for device, test in tests), return_exceptions=True)
     for r in results:
         if isinstance(r, Exception):
             logger.error(f"Error when running tests: {r.__class__.__name__}: {r}")

--- a/.github/scripts/anta-tester.py
+++ b/.github/scripts/anta-tester.py
@@ -93,7 +93,7 @@ def cli_manager() -> argparse.Namespace:
     parser.add_argument('--enable_password', '-e', required=False,
                         default='ansible', help='EOS Enable Password')
 
-    parser.add_argument('--timeout', required=False,
+    parser.add_argument('--timeout', required=False, type=float,
                         default=0.5, help='eAPI connection timeout')
 
     #############################
@@ -200,7 +200,7 @@ if __name__ == '__main__':
         username=cli_options.username,
         password=cli_options.password,
         enable_password=cli_options.enable_password,
-        timeout=0.5,
+        timeout=cli_options.timeout,
         filter_hosts=cli_options.search_host
         )
     logger.info(f'Inventory {cli_options.inventory} loaded')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -42,7 +42,7 @@ jobs:
     needs: [linting]
     strategy:
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10"]
+        python: ["3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,7 @@
         "${workspaceFolder}/.personal/ceos-catalog.yml",
         "--table",
         "--timeout",
-        "1"
+        "5"
       ]
     },  
     {
@@ -37,7 +37,7 @@
             "-i", "${workspaceFolder}/.personal/inventory.yaml",
             "-c", "${workspaceFolder}/examples/tests_all.yaml",
             "--timeout",
-            "1"
+            "5"
         ],
         "console": "integratedTerminal"
     },
@@ -56,7 +56,7 @@
             "-i", "${workspaceFolder}/.personal/inventory.yaml",
             "-c", "${workspaceFolder}/examples/tests_subset.yaml",
             "--timeout",
-            "1"
+            "5"
         ],
         "console": "integratedTerminal"
     }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,6 +26,7 @@
         "name": "ANTA Tester - All tests",
         "type": "python",
         "request": "launch",
+        "justMyCode": false,
         "program": "${workspaceFolder}/.github/scripts/anta-tester.py",
         "args": [
             "-u", "admin",
@@ -34,7 +35,9 @@
             "-l",
             "--very-verbose",
             "-i", "${workspaceFolder}/.personal/inventory.yaml",
-            "-c", "${workspaceFolder}/examples/tests_all.yaml"
+            "-c", "${workspaceFolder}/examples/tests_all.yaml",
+            "--timeout",
+            "1"
         ],
         "console": "integratedTerminal"
     },
@@ -42,6 +45,7 @@
         "name": "ANTA Tester - Test subset",
         "type": "python",
         "request": "launch",
+        "justMyCode": false,
         "program": "${workspaceFolder}/.github/scripts/anta-tester.py",
         "args": [
             "-u", "admin",
@@ -50,7 +54,9 @@
             "-l",
             "--very-verbose",
             "-i", "${workspaceFolder}/.personal/inventory.yaml",
-            "-c", "${workspaceFolder}/examples/tests_subset.yaml"
+            "-c", "${workspaceFolder}/examples/tests_subset.yaml",
+            "--timeout",
+            "1"
         ],
         "console": "integratedTerminal"
     }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,27 +1,58 @@
 {
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "check-devices debug",
-            "type": "python",
-            "request": "launch",
-            "program": "${workspaceFolder}/scripts/check-devices.py",
-            "args": [
-                "-u",
-                "admin",
-                "-p",
-                "admin123",
-                "-log",
-                "INFO",
-                "-i",
-                "${workspaceFolder}/.personal/avd-lab.yml",
-                "-c",
-                "${workspaceFolder}/.personal/ceos-catalog.yml",
-                "--table",
-                "--timeout",
-                "1"
-            ],
-            "console": "integratedTerminal"
-        }
-    ]
-}
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "check-devices debug",
+      "type": "python",
+      "request": "launch",
+      "program": "${workspaceFolder}/scripts/check-devices.py",
+      "args": [
+        "-u",
+        "admin",
+        "-p",
+        "admin123",
+        "-log",
+        "INFO",
+        "-i",
+        "${workspaceFolder}/.personal/avd-lab.yml",
+        "-c",
+        "${workspaceFolder}/.personal/ceos-catalog.yml",
+        "--table",
+        "--timeout",
+        "1"
+      ]
+    },  
+    {
+        "name": "ANTA Tester - All tests",
+        "type": "python",
+        "request": "launch",
+        "program": "${workspaceFolder}/.github/scripts/anta-tester.py",
+        "args": [
+            "-u", "admin",
+            "-p",  "admin",
+            "-e", "admin",
+            "-l",
+            "--very-verbose",
+            "-i", "${workspaceFolder}/.personal/inventory.yaml",
+            "-c", "${workspaceFolder}/examples/tests_all.yaml"
+        ],
+        "console": "integratedTerminal"
+    },
+    {
+        "name": "ANTA Tester - Test subset",
+        "type": "python",
+        "request": "launch",
+        "program": "${workspaceFolder}/.github/scripts/anta-tester.py",
+        "args": [
+            "-u", "admin",
+            "-p",  "admin",
+            "-e", "admin",
+            "-l",
+            "--very-verbose",
+            "-i", "${workspaceFolder}/.personal/inventory.yaml",
+            "-c", "${workspaceFolder}/examples/tests_subset.yaml"
+        ],
+        "console": "integratedTerminal"
+    }
+  ]
+}   

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+    "python.linting.enabled": true,
+    "python.linting.flake8Enabled": true,
+    "python.linting.flake8Args": [
+      "--config=/dev/null",
+      "--max-line-length=165"
+    ],
+    "python.linting.pylintEnabled": true,
+    "python.linting.pylintArgs": [
+      "--rcfile=pylintrc"
+    ],
+    "python.linting.mypyEnabled": true,
+    "python.linting.mypyArgs": [
+      "--config-file=pyproject.toml"
+    ],
+}

--- a/anta/decorators.py
+++ b/anta/decorators.py
@@ -77,7 +77,7 @@ def check_bgp_family_enable(family: str) -> Callable[..., Callable[..., TestResu
                 "show bgp rt-membership summary" if family == "rtc" else eapi_command
             )
 
-            result = TestResult(host=str(device.host), test=function.__name__)  # type: ignore
+            result = TestResult(name=str(device.name), test=function.__name__)  # type: ignore
             try:
                 response = device.session.runCmds(  # type: ignore
                     1, [eapi_command], "json"

--- a/anta/decorators.py
+++ b/anta/decorators.py
@@ -1,11 +1,8 @@
 """
 decorators for tests
 """
-import socket
 from functools import wraps
 from typing import Any, Callable, Dict, List
-
-from jsonrpclib import jsonrpc
 
 from anta.result_manager.models import TestResult
 
@@ -26,19 +23,20 @@ def skip_on_platforms(platforms: List[str]) -> Callable[..., Callable[..., TestR
         """
 
         @wraps(function)
-        def wrapper(*args: List[Any], **kwargs: Dict[str, Any]) -> TestResult:
+        async def wrapper(*args: List[Any], **kwargs: Dict[str, Any]) -> TestResult:
             """
             wrapper for func
             """
             device = args[0]
-            if device.hw_model in platforms:  # type:ignore
-                result = TestResult(name=device.name, test=function.__name__)  # type: ignore
+            if device.hw_model in platforms:
+                result = TestResult(
+                    name=device.name, test=function.__name__)
                 result.is_skipped(
-                    f"{wrapper.__name__} test is not supported on {device.hw_model}."  # type: ignore
+                    f"{wrapper.__name__} test is not supported on {device.hw_model}."
                 )
                 return result
 
-            return function(*args, **kwargs)
+            return await function(*args, **kwargs)
 
         return wrapper
 
@@ -61,7 +59,7 @@ def check_bgp_family_enable(family: str) -> Callable[..., Callable[..., TestResu
         """
 
         @wraps(function)
-        def wrapper(*args: List[Any], **kwargs: Dict[str, Any]) -> TestResult:
+        async def wrapper(*args: List[Any], **kwargs: Dict[str, Any]) -> TestResult:
             """
             wrapper for func
             """
@@ -77,34 +75,24 @@ def check_bgp_family_enable(family: str) -> Callable[..., Callable[..., TestResu
                 "show bgp rt-membership summary" if family == "rtc" else eapi_command
             )
 
-            result = TestResult(name=str(device.name), test=function.__name__)  # type: ignore
-            try:
-                response = device.session.runCmds(  # type: ignore
-                    1, [eapi_command], "json"
-                )  # type: ignore
+            result = TestResult(name=str(device.name), test=function.__name__)
+            response = await device.session.cli(
+                command=eapi_command, ofmt="json")
 
-                if "vrfs" not in response[0].keys():
-                    result.is_skipped(
-                        # type: ignore
-                        f"no BGP configuration for {family} on this device"
-                    )
-                    return result
-                bgp_vrfs = response[0]["vrfs"]
-                if (
-                    len(bgp_vrfs) == 0
-                    or len(response[0]["vrfs"]["default"]["peers"]) == 0
-                ):
-                    # No VRF
-                    result.is_skipped(
-                        # type: ignore
-                        f"no {family} peer on this device"
-                    )
-                    return result
-            except (jsonrpc.AppError, KeyError, socket.timeout) as e:
-                result.is_error(str(e))
+            if "vrfs" not in response.keys():
+                result.is_skipped(
+                    f"no BGP configuration for {family} on this device"
+                )
+                return result
+            if (len(bgp_vrfs := response["vrfs"]) == 0
+                or len(bgp_vrfs["default"]["peers"]) == 0):
+                # No VRF
+                result.is_skipped(
+                    f"no {family} peer on this device"
+                )
                 return result
 
-            return function(*args, **kwargs)
+            return await function(*args, **kwargs)
 
         return wrapper
 

--- a/anta/decorators.py
+++ b/anta/decorators.py
@@ -2,12 +2,12 @@
 decorators for tests
 """
 from functools import wraps
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Coroutine, Dict, List
 
 from anta.result_manager.models import TestResult
 
 
-def skip_on_platforms(platforms: List[str]) -> Callable[..., Callable[..., TestResult]]:
+def skip_on_platforms(platforms: List[str]) -> Callable[..., Callable[..., Coroutine[Any, Any, TestResult]]]:
     """
     Decorator factory to skip a test on a list of platforms
 
@@ -16,14 +16,14 @@ def skip_on_platforms(platforms: List[str]) -> Callable[..., Callable[..., TestR
 
     """
 
-    def decorator(function: Callable[..., TestResult]) -> Callable[..., TestResult]:
+    def decorator(function: Callable[..., TestResult]) -> Callable[..., Coroutine[Any, Any, TestResult]]:
         """
         Decorator to skip a test ona list of platform
         * func (Callable): the test to be decorated
         """
 
         @wraps(function)
-        async def wrapper(*args: List[Any], **kwargs: Dict[str, Any]) -> TestResult:
+        async def wrapper(*args: Any, **kwargs: Dict[str, Any]) -> TestResult:
             """
             wrapper for func
             """
@@ -43,7 +43,7 @@ def skip_on_platforms(platforms: List[str]) -> Callable[..., Callable[..., TestR
     return decorator
 
 
-def check_bgp_family_enable(family: str) -> Callable[..., Callable[..., TestResult]]:
+def check_bgp_family_enable(family: str) -> Callable[..., Callable[..., Coroutine[Any, Any, TestResult]]]:
     """
     Decorator factory to skip a test if BGP is enabled
 
@@ -52,14 +52,14 @@ def check_bgp_family_enable(family: str) -> Callable[..., Callable[..., TestResu
 
     """
 
-    def decorator(function: Callable[..., TestResult]) -> Callable[..., TestResult]:
+    def decorator(function: Callable[..., TestResult]) -> Callable[..., Coroutine[Any, Any, TestResult]]:
         """
         Decorator to skip a test ona list of platform
         * func (Callable): the test to be decorated
         """
 
         @wraps(function)
-        async def wrapper(*args: List[Any], **kwargs: Dict[str, Any]) -> TestResult:
+        async def wrapper(*args: Any, **kwargs: Dict[str, Any]) -> TestResult:
             """
             wrapper for func
             """
@@ -85,7 +85,7 @@ def check_bgp_family_enable(family: str) -> Callable[..., Callable[..., TestResu
                 )
                 return result
             if (len(bgp_vrfs := response["vrfs"]) == 0
-                or len(bgp_vrfs["default"]["peers"]) == 0):
+               or len(bgp_vrfs["default"]["peers"]) == 0):
                 # No VRF
                 result.is_skipped(
                     f"no {family} peer on this device"

--- a/anta/decorators.py
+++ b/anta/decorators.py
@@ -32,7 +32,7 @@ def skip_on_platforms(platforms: List[str]) -> Callable[..., Callable[..., TestR
             """
             device = args[0]
             if device.hw_model in platforms:  # type:ignore
-                result = TestResult(host=str(device.host), test=function.__name__)  # type: ignore
+                result = TestResult(name=device.name, test=function.__name__)  # type: ignore
                 result.is_skipped(
                     f"{wrapper.__name__} test is not supported on {device.hw_model}."  # type: ignore
                 )

--- a/anta/inventory/__init__.py
+++ b/anta/inventory/__init__.py
@@ -8,7 +8,6 @@ Inventory Module for ANTA.
 import logging
 import asyncio
 from typing import List, Optional, Union
-from aioeapi import Device
 from aioeapi.errors import EapiCommandError
 
 import yaml
@@ -103,7 +102,7 @@ class AntaInventory:
 
     # pylint: disable=R0913
     def __init__(self, inventory_file: str, username: str, password: str,
-                 enable_password: str = None, timeout: float = 10.0,
+                 enable_password: str = None, timeout: float = None,
                  filter_hosts: List[str] = None) -> None:
         """Class constructor.
 
@@ -111,8 +110,8 @@ class AntaInventory:
             inventory_file (str): Path to inventory YAML file where user has described his inputs
             username (str): Username to use to connect to devices
             password (str): Password to use to connect to devices
-            timeout (float, optional): timeout in seconds for every API call. Defaults to 10sec.
-            filter_hosts (str, optional): create inventory only with matching host name in this list. Empty list disable the filter.
+            timeout (float, optional): timeout in seconds for every API call.
+            filter_hosts (str, optional): create inventory only with matching host name in this list.
         """
         self.set_credentials(username, password, enable_password)
         self.timeout = timeout
@@ -145,11 +144,6 @@ class AntaInventory:
             for device in self._inventory:
                 if device.url.host not in filter_hosts:
                     del device
-
-        for device in self._inventory:
-            device.session = Device(host=device.url.host, port=device.url.port,
-                                    username=device.url.user, password=device.url.password,
-                                    proto=device.url.scheme, timeout=self.timeout)
 
     ###########################################################################
     # Boolean methods
@@ -262,10 +256,11 @@ class AntaInventory:
             name=name,
             host=host,
             port=port,
-            user=self._username,
+            username=self._username,
             password=self._password,
             enable_password=self._enable_password,
-            tags=tags
+            tags=tags,
+            timeout=self.timeout
         )
         self._inventory.append(device)
 

--- a/anta/inventory/__init__.py
+++ b/anta/inventory/__init__.py
@@ -185,8 +185,7 @@ class AntaInventory:
         if not online:
             logger.warning(f'Cannot open port to {device.name}')
             return False
-        else:
-            return True
+        return True
 
     ###########################################################################
     # Internal methods

--- a/anta/inventory/__init__.py
+++ b/anta/inventory/__init__.py
@@ -7,7 +7,7 @@ Inventory Module for ANTA.
 
 import logging
 import asyncio
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Any, Dict
 from aioeapi.errors import EapiCommandError
 
 import yaml
@@ -251,16 +251,18 @@ class AntaInventory:
         if tags is None:
             tags = [DEFAULT_TAG]
 
-        device = InventoryDevice(
-            name=name,
-            host=host,
-            port=port,
-            username=self._username,
-            password=self._password,
-            enable_password=self._enable_password,
-            tags=tags,
-            timeout=self.timeout
-        )
+        kwargs: Dict[str, Any] = {
+            'name': name,
+            'host': host,
+            'port': port,
+            'username': self._username,
+            'password': self._password,
+            'enable_password': self._enable_password,
+            'tags': tags
+        }
+        if self.timeout:
+            kwargs['timeout'] = self.timeout
+        device = InventoryDevice(**kwargs)
         self._inventory.append(device)
 
     def _inventory_read_hosts(self) -> None:
@@ -364,8 +366,8 @@ class AntaInventory:
             # pylint: disable=R1721
             return [dev for dev in inventory]
 
-        if format_out == "json":
-            return inventory.json()
+        if format_out == 'json':
+            return inventory.json(exclude={'__root__': {'__all__': {'session'}}})
 
         return inventory
 

--- a/anta/inventory/__init__.py
+++ b/anta/inventory/__init__.py
@@ -6,14 +6,12 @@ Inventory Module for ANTA.
 """
 
 import logging
-import ssl
 import asyncio
 from typing import List, Optional, Union
 from aioeapi import Device
 from aioeapi.errors import EapiCommandError
 
 import yaml
-from jinja2 import Template
 from jsonrpclib import Server
 from netaddr import IPAddress, IPNetwork
 from pydantic import ValidationError
@@ -25,9 +23,6 @@ from .models import (DEFAULT_TAG, AntaInventoryInput, InventoryDevice,
                      InventoryDevices)
 
 # pylint: disable=W1309
-
-# pylint: disable=W0212
-ssl._create_default_https_context = ssl._create_unverified_context
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -100,11 +95,7 @@ class AntaInventory:
     """
 
     # Root key of inventory part of the inventory file
-    INVENTORY_ROOT_KEY = "anta_inventory"
-    # Template to build eAPI connection URL
-    EAPI_SESSION_TPL = (
-        "https://{{device_username}}:{{device_password}}@{{device}}/command-api"
-    )
+    INVENTORY_ROOT_KEY = 'anta_inventory'
     # Supported Output format
     INVENTORY_OUTPUT_FORMAT = ["native", "json"]
     # HW model definition in show version
@@ -164,7 +155,7 @@ class AntaInventory:
     # Boolean methods
     ###########################################################################
 
-    def _is_ip_exist(self, ip: str) -> bool:
+    def _is_ip_exist(self, ip: str) -> bool:  # TODO mtache: unused, remove this ?
         """Check if an IP is part of the current inventory.
 
         Args:
@@ -247,8 +238,6 @@ class AntaInventory:
         """
         logger.debug(f'Refreshing device {device.name}')
         device.is_online, hw_model = await asyncio.gather(self._is_device_online(device=device), self._read_device_hw(device=device))
-        # device.is_online = await self._is_device_online(device=device)
-        # hw_model = await self._read_device_hw(device=device)
         if device.is_online and hw_model:
             device.established = True
             device.hw_model = hw_model
@@ -386,7 +375,7 @@ class AntaInventory:
 
         return inventory
 
-    def get_device(self, host_ip: str) -> Optional[InventoryDevice]:
+    def get_device(self, host_ip: str) -> Optional[InventoryDevice]:  # TODO mtache: unused, remove this ?
         """Get device information from a given IP.
 
         Args:
@@ -399,7 +388,7 @@ class AntaInventory:
             return [dev for dev in self._inventory if str(dev.host) == str(host_ip)][0]
         return None
 
-    def get_device_session(self, host_ip: str) -> Server:
+    def get_device_session(self, host_ip: str) -> Server:  # TODO mtache: unused, remove this ?
         """Expose RPC session of a given host from our inventory.
 
         Provide RPC session if the session exists, if not, it returns None

--- a/anta/inventory/__init__.py
+++ b/anta/inventory/__init__.py
@@ -112,14 +112,16 @@ class AntaInventory:
 
     # pylint: disable=R0913
     def __init__(self, inventory_file: str, username: str, password: str,
-                 enable_password: str = None, timeout: float = 5.0) -> None:
+                 enable_password: str = None, timeout: float = 10.0,
+                 filter_hosts: List[str] = None) -> None:
         """Class constructor.
 
         Args:
             inventory_file (str): Path to inventory YAML file where user has described his inputs
             username (str): Username to use to connect to devices
             password (str): Password to use to connect to devices
-            timeout (float, optional): Timeout in second to wait before marking device down. Defaults to 5sec.
+            timeout (float, optional): timeout in seconds for every API call. Defaults to 10sec.
+            filter_hosts (str, optional): create inventory only with matching host name in this list. Empty list disable the filter.
         """
         self.set_credentials(username, password, enable_password)
         self.timeout = timeout
@@ -147,6 +149,11 @@ class AntaInventory:
             self._inventory_read_networks()
         if self._read_inventory.dict()["ranges"] is not None:
             self._inventory_read_ranges()
+
+        if filter_hosts:
+            for device in self._inventory:
+                if device.url.host not in filter_hosts:
+                    del device
 
         for device in self._inventory:
             device.session = Device(host=device.url.host, port=device.url.port,

--- a/anta/inventory/__init__.py
+++ b/anta/inventory/__init__.py
@@ -5,12 +5,12 @@
 Inventory Module for ANTA.
 """
 
-import logging
 import asyncio
-from typing import List, Optional, Union, Any, Dict
-from aioeapi.errors import EapiCommandError
+import logging
+from typing import Any, Dict, List, Optional, Union
 
 import yaml
+from aioeapi.errors import EapiCommandError
 from jsonrpclib import Server
 from netaddr import IPAddress, IPNetwork
 from pydantic import ValidationError

--- a/anta/inventory/__init__.py
+++ b/anta/inventory/__init__.py
@@ -9,7 +9,7 @@ import logging
 import ssl
 from concurrent.futures import ThreadPoolExecutor
 from socket import setdefaulttimeout
-from typing import Any, Iterator, List, Optional, Union
+from typing import Iterator, List, Optional, Union
 
 import yaml
 from jinja2 import Template
@@ -367,7 +367,7 @@ class AntaInventory:
                 self._add_device_to_inventory(str(range_increment), tags=range_def.tags)
                 range_increment += 1
 
-    def _inventory_rebuild(self, list_devices: Iterator[Any]) -> InventoryDevices:
+    def _inventory_rebuild(self, list_devices: Iterator[InventoryDevice]) -> InventoryDevices:
         """
         _inventory_rebuild Transform a list of InventoryDevice into a InventoryDevices object.
 
@@ -516,8 +516,10 @@ class AntaInventory:
         """
         logger.debug(
             f"Searching for device {device.name} in {[ dev.name for dev in self._inventory]}")
-        device = [dev for dev in self._inventory if dev == device][0] or None
-        if device is None:
+        devices = [dev for dev in self._inventory if dev == device]
+        if len(devices) == 1:
+            device = devices[0]
+        else:
             return False
         logger.debug(f'Search result is: {device}')
         if device.is_online and not device.established:

--- a/anta/inventory/__init__.py
+++ b/anta/inventory/__init__.py
@@ -419,7 +419,7 @@ class AntaInventory:
     async def connect_inventory(self) -> None:
         """connect_inventory Helper to prepare inventory with network data."""
         logger.debug('Refreshing facts for current inventory')
-        results = await asyncio.gather(*(self._refresh_device_fact(device) for device in self._inventory), return_exceptions=False)
+        results = await asyncio.gather(*(self._refresh_device_fact(device) for device in self._inventory), return_exceptions=True)
         for r in results:
             if isinstance(r, Exception):
                 logger.error(f"Error when connecting to device: {r.__class__.__name__}: {r}")

--- a/anta/inventory/models.py
+++ b/anta/inventory/models.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import Dict, List, Optional, Any, Iterator, Type
 from pydantic.networks import Parts
 from pydantic import BaseModel, IPvAnyAddress, IPvAnyNetwork, AnyHttpUrl, conint, root_validator
+from aioeapi import Device
 
 # Default values
 
@@ -132,12 +133,14 @@ class InventoryDevice(BaseModel):
         url (str): eAPI URL to use to build session.
         tags (List[str]): List of attached tags read from inventory file.
     """
+    class Config:
+        arbitrary_types_allowed = True
 
     name: str
     user: str  # TODO: duplicate with url.user
     password: str  # TODO: duplicate with url.password
     enable_password: Optional[str]
-    session: Any
+    session: Optional[Device]
     established = False
     is_online = False
     hw_model: str = DEFAULT_HW_MODEL

--- a/anta/inventory/models.py
+++ b/anta/inventory/models.py
@@ -3,9 +3,9 @@
 
 """Models related to inventory management."""
 
-from typing import List, Optional, Iterator
+from typing import Dict, List, Optional, Any, Iterator, Type
 
-from pydantic import BaseModel, IPvAnyAddress, IPvAnyNetwork, conint
+from pydantic import BaseModel, IPvAnyAddress, IPvAnyNetwork, conint, root_validator
 from aioeapi import Device
 
 # Default values
@@ -92,7 +92,9 @@ class InventoryDevice(BaseModel):
         url (str): eAPI URL to use to build session.
         tags (List[str]): List of attached tags read from inventory file.
     """
-    class Config:
+
+    class Config:  # pylint: disable=too-few-public-methods
+        """ Pydantic model configuration """
         arbitrary_types_allowed = True
 
     name: str
@@ -106,7 +108,9 @@ class InventoryDevice(BaseModel):
     tags: List[str] = [DEFAULT_TAG]
     timeout: float = 10.0
 
-    def build_device(cls, values):
+    @root_validator(pre=True)
+    def build_device(cls: Type[Any], values: Dict[str, Any]) -> Dict[str, Any]:
+        """ Build the device session object """
         if values.get('session') is None:
             host = values.get('host')
             if not host:

--- a/anta/inventory/models.py
+++ b/anta/inventory/models.py
@@ -3,10 +3,11 @@
 
 """Models related to inventory management."""
 
-from typing import Dict, List, Optional, Any, Iterator, Type, Union
+from typing import Any, Dict, Iterator, List, Optional, Type, Union
 
-from pydantic import BaseModel, IPvAnyAddress, IPvAnyNetwork, conint, constr, root_validator
 from aioeapi import Device
+from pydantic import (BaseModel, IPvAnyAddress, IPvAnyNetwork, conint, constr,
+                      root_validator)
 
 # Default values
 

--- a/anta/inventory/models.py
+++ b/anta/inventory/models.py
@@ -3,9 +3,9 @@
 
 """Models related to inventory management."""
 
-from typing import Any, Iterator, List, Optional
-
-from pydantic import BaseModel, IPvAnyAddress, IPvAnyNetwork
+from typing import List, Optional, Any, Iterator
+from pydantic.networks import Parts
+from pydantic import BaseModel, IPvAnyAddress, IPvAnyNetwork, AnyHttpUrl, conint, root_validator
 
 # Default values
 
@@ -24,7 +24,9 @@ class AntaInventoryHost(BaseModel):
         tags (List[str]): List of attached tags read from inventory file.
     """
 
-    host: IPvAnyAddress
+    name: Optional[str]
+    host: str
+    port: Optional[conint(gt=1, lt=65535)]
     tags: List[str] = [DEFAULT_TAG]
 
 
@@ -118,7 +120,7 @@ class InventoryDevice(BaseModel):
     Inventory model exposed by Inventory class.
 
     Attributes:
-        host (IPvAnyAddress): IPv4 or IPv6 address of the device.
+        name (str): Device name
         username (str): Username to use for connection.
         password (password): Password to use for connection.
         enable_password (Optional[str]): enable_password to use on the device, required for some tests
@@ -130,16 +132,44 @@ class InventoryDevice(BaseModel):
         tags (List[str]): List of attached tags read from inventory file.
     """
 
-    host: IPvAnyAddress
-    username: str
-    password: str
+    name: str
+    user: str  # TODO: duplicate with url.user
+    password: str  # TODO: duplicate with url.password
     enable_password: Optional[str]
     session: Any
     established = False
     is_online = False
     hw_model: str = DEFAULT_HW_MODEL
-    url: str
+    url: eAPIUrl
     tags: List[str] = [DEFAULT_TAG]
+
+    @root_validator(pre=True)
+    def build_name(cls, values):
+        """ Build name attribute """
+        if values.get('name') is None:
+            assert 'host' in values, 'host required if name is not provided'
+            values['name'] = f"{values.get('host')}:{values.get('url').get('port')}"
+        return values
+
+    @root_validator(pre=True)
+    def build_eapi_url(cls, values):
+        """ Build url attribute """
+        if values.get('url') is None:
+            if values.get('host') is not None:
+                # Ensure the host field is a string
+                values.update(host=str(values['host']))
+            if values.get('port') is not None:
+                # Ensure the port field is a string
+                values.update(port=str(values['port']))
+            values['url'] = eAPIUrl.build(**values)
+        return values
+
+    def __eq__(self, other):
+        """
+            Two InventoryDevice objects are equal if the hostname and the port are the same.
+            This covers the use case of port forwarding when the host is localhost and the devices have different ports.
+        """
+        return self.url.host == other.url.host and self.url.port == other.url.port
 
     def assert_enable_password_is_not_none(self, test_name: Optional[str] = None) -> None:
         """

--- a/anta/inventory/models.py
+++ b/anta/inventory/models.py
@@ -3,9 +3,9 @@
 
 """Models related to inventory management."""
 
-from typing import Dict, List, Optional, Any, Iterator, Type
+from typing import Dict, List, Optional, Any, Iterator, Type, Union
 
-from pydantic import BaseModel, IPvAnyAddress, IPvAnyNetwork, conint, root_validator
+from pydantic import BaseModel, IPvAnyAddress, IPvAnyNetwork, conint, constr, root_validator
 from aioeapi import Device
 
 # Default values
@@ -14,6 +14,8 @@ DEFAULT_TAG = 'default'
 DEFAULT_HW_MODEL = 'unset'
 
 # Pydantic models for input validation
+
+RFC_1123_REGEX = r'^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$'
 
 
 class AntaInventoryHost(BaseModel):
@@ -26,7 +28,7 @@ class AntaInventoryHost(BaseModel):
     """
 
     name: Optional[str]
-    host: str
+    host: Union[constr(regex=RFC_1123_REGEX), IPvAnyAddress]  # type: ignore
     port: Optional[conint(gt=1, lt=65535)]  # type: ignore
     tags: List[str] = [DEFAULT_TAG]
 
@@ -98,8 +100,10 @@ class InventoryDevice(BaseModel):
         arbitrary_types_allowed = True
 
     name: str
+    host: Union[constr(regex=RFC_1123_REGEX), IPvAnyAddress]  # type: ignore
     username: str
     password: str
+    port: Optional[conint(gt=1, lt=65535)]  # type: ignore
     enable_password: Optional[str]
     session: Device
     established = False

--- a/anta/inventory/models.py
+++ b/anta/inventory/models.py
@@ -73,6 +73,45 @@ class AntaInventoryInput(BaseModel):
 
 # Pydantic models for inventory output structures
 
+class eAPIUrl(AnyHttpUrl):
+    """
+    eAPI URL field type
+    The build method has been overriden to provide default value of a eAPI endpoint when using it.
+
+    Examples:
+    In : eAPIUrl.build()
+    Out: 'http://localhost:8080/command-api'
+
+    In : eAPIUrl.build(host='1.1.1.1')
+    Out: 'https://1.1.1.1:443/command-api'
+
+    In : eAPIUrl.build(host='1.1.1.1', port='80')
+    Out: 'http://1.1.1.1:80/command-api'
+    """
+    allowed_schemes = {'http', 'https'}
+    host_required = True
+
+    @staticmethod
+    def get_default_parts(parts: 'Parts') -> 'Parts':
+        return {
+            'scheme': 'http' if ((parts.get('port') in ['80', '8080']) or parts.get('host') is None) else 'https',
+            'domain': 'localhost' if (parts.get('port') == '8080') else '',
+            'port': '8080' if (parts.get('host') is None) else '443',
+            'path': '/command-api',
+        }
+
+    @classmethod
+    def build(cls, **kwargs):
+        """
+        Include default path and port when building an eAPI URL
+        """
+        parts = Parts(**kwargs)
+        default = cls.get_default_parts(parts)
+        for field in default:
+            if field not in kwargs:
+                kwargs.update({field: default.get(field)})
+        return super().build(**kwargs)
+
 
 class InventoryDevice(BaseModel):
     """

--- a/anta/inventory/models.py
+++ b/anta/inventory/models.py
@@ -31,7 +31,6 @@ class AntaInventoryHost(BaseModel):
     port: Optional[conint(gt=1, lt=65535)]  # type: ignore
     tags: List[str] = [DEFAULT_TAG]
 
-
 class AntaInventoryNetwork(BaseModel):
     """
     Network definition for user's inventory.

--- a/anta/loader.py
+++ b/anta/loader.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 def parse_catalog(
-    test_catalog: Dict[Any, Any], package: Optional[str] = None
+    test_catalog: Dict[Any, Any], package: Optional[str] = 'anta.tests'
 ) -> List[Tuple[Callable[..., TestResult], Dict[Any, Any]]]:
     """
     Function to pase the catalog and return a list of tests
@@ -33,7 +33,7 @@ def parse_catalog(
         try:
             module = importlib.import_module(f"{key}")
         except ModuleNotFoundError:
-            logger.error(f"No test module named '{key}")
+            logger.error(f"No test module named '{key}'")
             sys.exit(1)
         if isinstance(value, list):
             # This is a list of tests

--- a/anta/loader.py
+++ b/anta/loader.py
@@ -23,7 +23,7 @@ def parse_catalog(
     Returns:
         List[Tuple[Callable[..., TestResult], Dict[Any, Any]]]: List of python function tests to run.
     """
-    tests = []
+    tests: List[Tuple[Callable[..., TestResult], Dict[Any, Any]]] = []
     if not test_catalog:
         return tests
     for key, value in test_catalog.items():

--- a/anta/loader.py
+++ b/anta/loader.py
@@ -24,6 +24,8 @@ def parse_catalog(
         List[Tuple[Callable[..., TestResult], Dict[Any, Any]]]: List of python function tests to run.
     """
     tests = []
+    if not test_catalog:
+        return tests
     for key, value in test_catalog.items():
         # Reauired to manage iteration within a tests module
         if package is not None:

--- a/anta/loader.py
+++ b/anta/loader.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 def parse_catalog(
-    test_catalog: Dict[Any, Any], package: Optional[str] = 'anta.tests'
+    test_catalog: Dict[Any, Any], package: Optional[str] = None
 ) -> List[Tuple[Callable[..., TestResult], Dict[Any, Any]]]:
     """
     Function to pase the catalog and return a list of tests

--- a/anta/result_manager/__init__.py
+++ b/anta/result_manager/__init__.py
@@ -88,6 +88,15 @@ class ResultManager:
         logger.info(f'add new test result to manager: {entry}')
         self._result_entries.append(entry)
 
+    def add_test_results(self, entries: List[TestResult]) -> None:
+        """Add a list of results to the list
+
+        Args:
+            entries (List[TestResult]): list of TestResult data to add to the report
+        """
+        logger.info(f'add new list of results to manager: {[str(r) for r in entries]}')
+        self._result_entries.extend(entries)
+
     def get_results(self, output_format: str = "native") -> Any:
         """
         Expose list of all test results in different format

--- a/anta/result_manager/models.py
+++ b/anta/result_manager/models.py
@@ -3,7 +3,8 @@
 
 """Models related to anta.result_manager module."""
 
-from typing import List, Iterator
+from typing import Iterator, List
+
 from pydantic import BaseModel, validator
 
 RESULT_OPTIONS = ['unset', 'success', 'failure', 'error', 'skipped']

--- a/anta/result_manager/models.py
+++ b/anta/result_manager/models.py
@@ -3,9 +3,8 @@
 
 """Models related to anta.result_manager module."""
 
-from typing import Iterator, List
-
-from pydantic import BaseModel, IPvAnyAddress, validator
+from typing import List, Iterator
+from pydantic import BaseModel, validator
 
 RESULT_OPTIONS = ['unset', 'success', 'failure', 'error', 'skipped']
 
@@ -15,12 +14,12 @@ class TestResult(BaseModel):
     Describe result of a test from a single device.
 
     Attributes:
-        host (IPvAnyAddress): IPv4 or IPv6 address of the device where the test has run.
+        name (str): Device name where the test has run.
         test (str): Test name runs on the device.
         results (str): Result of the test. Can be one of unset / failure / success.
         message (str, optional): Message to report after the test.
     """
-    host: IPvAnyAddress
+    name: str
     test: str
     result: str = 'unset'
     messages: List[str] = []

--- a/anta/result_manager/models.py
+++ b/anta/result_manager/models.py
@@ -120,6 +120,10 @@ class ListResult(BaseModel):
 
     __root__: List[TestResult] = []
 
+    def extend(self, values: List[TestResult]) -> None:
+        """Add support for extend method."""
+        self.__root__.extend(values)
+
     def append(self, value: TestResult) -> None:
         """Add support for append method."""
         self.__root__.append(value)

--- a/anta/tests/__init__.py
+++ b/anta/tests/__init__.py
@@ -7,6 +7,7 @@ Test decorator from which tests can derive
 import logging
 from functools import wraps
 from typing import Any, Callable, Coroutine, Dict, List
+import traceback
 
 from anta.inventory.models import InventoryDevice
 from anta.result_manager.models import TestResult
@@ -45,9 +46,10 @@ def anta_test(function: Callable[..., Coroutine[Any, Any, TestResult]]) -> Calla
         # In this case we want to catch all exceptions
         except Exception as e:  # pylint: disable=broad-except
             logger.error(
-                f"exception raised for {function.__name__} -  {device.host}: {str(e)}"
+                f"Exception raised for test {function.__name__} (on device {device.host}) - {type(e).__name__}: {str(e)}"
             )
-            result.is_error(str(e))
+            logger.debug(traceback.format_exc())
+            result.is_error(f'{type(e).__name__}: {str(e)}')
             return result
 
     return wrapper

--- a/anta/tests/__init__.py
+++ b/anta/tests/__init__.py
@@ -5,9 +5,9 @@ Test decorator from which tests can derive
 """
 
 import logging
+import traceback
 from functools import wraps
 from typing import Any, Callable, Coroutine, Dict, List
-import traceback
 
 from anta.inventory.models import InventoryDevice
 from anta.result_manager.models import TestResult

--- a/anta/tests/__init__.py
+++ b/anta/tests/__init__.py
@@ -6,7 +6,7 @@ Test decorator from which tests can derive
 
 import logging
 from functools import wraps
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Coroutine
 
 from anta.inventory.models import InventoryDevice
 from anta.result_manager.models import TestResult
@@ -14,14 +14,14 @@ from anta.result_manager.models import TestResult
 logger = logging.getLogger(__name__)
 
 
-def anta_test(function: Callable[..., TestResult]) -> Callable[..., TestResult]:
+def anta_test(function: Callable[..., Coroutine[Any, Any, TestResult]]) -> Callable[..., Coroutine[Any, Any, Coroutine[Any, Any, TestResult]]]:
     """
     Decorator to generate the structure for a test
     * func (Callable): the test to be decorated
     """
 
     @wraps(function)
-    def wrapper(
+    async def wrapper(
         device: InventoryDevice, *args: List[Any], **kwargs: Dict[str, Any]
     ) -> TestResult:
         """
@@ -36,11 +36,11 @@ def anta_test(function: Callable[..., TestResult]) -> Callable[..., TestResult]:
             * result = "failure" otherwise.
             * result = "error" if any exception is caught
         """
-        result = TestResult(host=str(device.host), test=function.__name__)  # type: ignore
-        logger.debug(f"Start {function.__name__} test for host {device.host}")
+        result = TestResult(name=str(device.host), test=function.__name__)
+        logger.debug(f"Start {function.__name__} check for host {device.host}")
 
         try:
-            return function(device, result, *args, **kwargs)
+            return await function(device, result, *args, **kwargs)
 
         # In this case we want to catch all exceptions
         except Exception as e:  # pylint: disable=broad-except

--- a/anta/tests/__init__.py
+++ b/anta/tests/__init__.py
@@ -6,7 +6,7 @@ Test decorator from which tests can derive
 
 import logging
 from functools import wraps
-from typing import Any, Callable, Dict, List, Coroutine
+from typing import Any, Callable, Coroutine, Dict, List
 
 from anta.inventory.models import InventoryDevice
 from anta.result_manager.models import TestResult

--- a/anta/tests/configuration.py
+++ b/anta/tests/configuration.py
@@ -2,10 +2,9 @@
 Test functions related to the device configuration
 """
 import logging
-
+from anta.tests import anta_test
 from anta.inventory.models import InventoryDevice
 from anta.result_manager.models import TestResult
-from anta.tests import anta_test
 
 logger = logging.getLogger(__name__)
 
@@ -61,10 +60,10 @@ async def verify_running_config_diffs(
 
     response = await device.session.cli(
         commands=[
-                  {"cmd": "enable", "input": str(device.enable_password)},
-                  "show running-config diffs",
-                 ],
-        ofmt="text",
+            {"cmd": "enable", "input": str(device.enable_password)},
+            "show running-config diffs",
+        ],
+        ofmt="text"
     )
     logger.debug(f"query result is: {response}")
 

--- a/anta/tests/configuration.py
+++ b/anta/tests/configuration.py
@@ -2,9 +2,10 @@
 Test functions related to the device configuration
 """
 import logging
-from anta.tests import anta_test
+
 from anta.inventory.models import InventoryDevice
 from anta.result_manager.models import TestResult
+from anta.tests import anta_test
 
 logger = logging.getLogger(__name__)
 

--- a/anta/tests/configuration.py
+++ b/anta/tests/configuration.py
@@ -61,10 +61,10 @@ async def verify_running_config_diffs(
 
     response = await device.session.cli(
         commands=[
-            {"cmd": "enable", "input": str(device.enable_password)},
-            "show running-config diffs",
-        ],
-        ofmt="text"
+                  {"cmd": "enable", "input": str(device.enable_password)},
+                  "show running-config diffs",
+                 ],
+        ofmt="text",
     )
     logger.debug(f"query result is: {response}")
 

--- a/anta/tests/hardware.py
+++ b/anta/tests/hardware.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 @skip_on_platforms(["cEOSLab", "vEOS-lab"])
 @anta_test
-def verify_transceivers_manufacturers(
+async def verify_transceivers_manufacturers(
     device: InventoryDevice,
     result: TestResult,
     manufacturers: Optional[List[str]] = None,
@@ -43,12 +43,12 @@ def verify_transceivers_manufacturers(
         )
         return result
 
-    response = device.session.runCmds(1, ["show inventory"], "json")
+    response = await device.session.cli(command="show inventory", ofmt="json")
     logger.debug(f"query result is: {response}")
 
     wrong_manufacturers = {
         interface: value["mfgName"]
-        for interface, value in response[0]["xcvrSlots"].items()
+        for interface, value in response["xcvrSlots"].items()
         if value["mfgName"] not in manufacturers
     }
 
@@ -65,7 +65,7 @@ def verify_transceivers_manufacturers(
 
 @skip_on_platforms(["cEOSLab", "vEOS-lab"])
 @anta_test
-def verify_system_temperature(
+async def verify_system_temperature(
     device: InventoryDevice, result: TestResult
 ) -> TestResult:
 
@@ -84,16 +84,16 @@ def verify_system_temperature(
         * result = "error" if any exception is caught
 
     """
-    response = device.session.runCmds(
-        1, ["show system environment temperature"], "json"
+    response = await device.session.cli(
+        command="show system environment temperature", ofmt="json"
     )
     logger.debug(f"query result is: {response}")
 
-    if response[0]["systemStatus"] == "temperatureOk":
+    if response["systemStatus"] == "temperatureOk":
         result.is_success()
     else:
         result.is_failure(
-            f"Device temperature is not OK, systemStatus: {response[0]['systemStatus'] }"
+            f"Device temperature is not OK, systemStatus: {response['systemStatus'] }"
         )
 
     return result
@@ -101,7 +101,7 @@ def verify_system_temperature(
 
 @skip_on_platforms(["cEOSLab", "vEOS-lab"])
 @anta_test
-def verify_transceiver_temperature(
+async def verify_transceiver_temperature(
     device: InventoryDevice, result: TestResult
 ) -> TestResult:
 
@@ -121,13 +121,13 @@ def verify_transceiver_temperature(
         * result = "error" if any exception is caught
 
     """
-    response = device.session.runCmds(
-        1, ["show system environment temperature transceiver"], "json"
+    response = await device.session.cli(
+        command="show system environment temperature transceiver", ofmt="json"
     )
     logger.debug(f"query result is: {response}")
 
     # Get the list of sensors
-    sensors = response[0]["tempSensors"]
+    sensors = response["tempSensors"]
 
     wrong_sensors = {
         sensor["name"]: {
@@ -150,7 +150,7 @@ def verify_transceiver_temperature(
 
 @skip_on_platforms(["cEOSLab", "vEOS-lab"])
 @anta_test
-def verify_environment_cooling(
+async def verify_environment_cooling(
     device: InventoryDevice, result: TestResult
 ) -> TestResult:
 
@@ -168,14 +168,14 @@ def verify_environment_cooling(
         * result = "error" if any exception is caught
 
     """
-    response = device.session.runCmds(1, ["show system environment cooling"], "json")
+    response = await device.session.cli(command="show system environment cooling", ofmt="json")
     logger.debug(f"query result is: {response}")
 
-    if response[0]["systemStatus"] == "coolingOk":
+    if response["systemStatus"] == "coolingOk":
         result.is_success()
     else:
         result.is_failure(
-            f"Device cooling is not OK, systemStatus: {response[0]['systemStatus'] }"
+            f"Device cooling is not OK, systemStatus: {response['systemStatus'] }"
         )
 
     return result
@@ -183,7 +183,7 @@ def verify_environment_cooling(
 
 @skip_on_platforms(["cEOSLab", "vEOS-lab"])
 @anta_test
-def verify_environment_power(device: InventoryDevice, result: TestResult) -> TestResult:
+async def verify_environment_power(device: InventoryDevice, result: TestResult) -> TestResult:
 
     """
     Verifies the power supplies status is OK.
@@ -199,12 +199,12 @@ def verify_environment_power(device: InventoryDevice, result: TestResult) -> Tes
         * result = "error" if any exception is caught
 
     """
-    response = device.session.runCmds(1, ["show system environment power"], "json")
+    response = await device.session.cli(command="show system environment power", ofmt="json")
     logger.debug(f"query result is: {response}")
 
     wrong_power_supplies = {
         powersupply: {"state": value["state"]}
-        for powersupply, value in response[0]["powerSupplies"].items()
+        for powersupply, value in response["powerSupplies"].items()
         if value["state"] != "ok"
     }
     if not wrong_power_supplies:
@@ -218,7 +218,7 @@ def verify_environment_power(device: InventoryDevice, result: TestResult) -> Tes
 
 @skip_on_platforms(["cEOSLab", "vEOS-lab"])
 @anta_test
-def verify_adverse_drops(device: InventoryDevice, result: TestResult) -> TestResult:
+async def verify_adverse_drops(device: InventoryDevice, result: TestResult) -> TestResult:
 
     """
     Verifies there is no adverse drops on DCS-7280E and DCS-7500E switches.
@@ -234,14 +234,14 @@ def verify_adverse_drops(device: InventoryDevice, result: TestResult) -> TestRes
         * result = "error" if any exception is caught
 
     """
-    response = device.session.runCmds(1, ["show hardware counter drop"], "json")
+    response = await device.session.cli(command="show hardware counter drop", ofmt="json")
     logger.debug(f"query result is: {response}")
 
-    if response[0]["totalAdverseDrops"] == 0:
+    if response["totalAdverseDrops"] == 0:
         result.is_success()
     else:
         result.is_failure(
-            f"Device TotalAdverseDrops counter is {response[0]['totalAdverseDrops']}."
+            f"Device TotalAdverseDrops counter is {response['totalAdverseDrops']}."
         )
 
     return result

--- a/anta/tests/multicast.py
+++ b/anta/tests/multicast.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 @anta_test
-def verify_igmp_snooping_vlans(
+async def verify_igmp_snooping_vlans(
     device: InventoryDevice, result: TestResult, vlans: List[str], configuration: str
 ) -> TestResult:
     """
@@ -38,16 +38,16 @@ def verify_igmp_snooping_vlans(
             "vlans or configuration was given"
         )
         return result
-    response = device.session.runCmds(1, ["show ip igmp snooping"], "json")
+    response = await device.session.cli(command="show ip igmp snooping", ofmt="json")
     logger.debug(f"query result is: {response}")
 
     result.is_success()
     for vlan in vlans:
-        if vlan not in response[0]["vlans"]:
+        if vlan not in response["vlans"]:
             result.is_failure(f"Supplied vlan {vlan} is not present on the device.")
             continue
 
-        igmp_state = response[0]["vlans"][str(vlan)]["igmpSnoopingState"]
+        igmp_state = response["vlans"][str(vlan)]["igmpSnoopingState"]
         if igmp_state != configuration:
             result.is_failure()
             result.messages.append(f"IGMP state for vlan {vlan} is {igmp_state}")
@@ -56,7 +56,7 @@ def verify_igmp_snooping_vlans(
 
 
 @anta_test
-def verify_igmp_snooping_global(
+async def verify_igmp_snooping_global(
     device: InventoryDevice, result: TestResult, configuration: str
 ) -> TestResult:
     """
@@ -80,10 +80,10 @@ def verify_igmp_snooping_global(
         )
         return result
 
-    response = device.session.runCmds(1, ["show ip igmp snooping"], "json")
+    response = await device.session.cli(command="show ip igmp snooping", ofmt="json")
     logger.debug(f"query result is: {response}")
 
-    igmp_state = response[0]["igmpSnoopingState"]
+    igmp_state = response["igmpSnoopingState"]
     if igmp_state == configuration:
         result.is_success()
     else:

--- a/anta/tests/profiles.py
+++ b/anta/tests/profiles.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 @skip_on_platforms(["cEOSLab", "VEOS-LAB"])
 @anta_test
-def verify_unified_forwarding_table_mode(
+async def verify_unified_forwarding_table_mode(
     device: InventoryDevice, result: TestResult, mode: str
 ) -> TestResult:
 
@@ -38,11 +38,9 @@ def verify_unified_forwarding_table_mode(
         )
         return result
 
-    response = device.session.runCmds(
-        1, ["show platform trident forwarding-table partition"], "json"
-    )
+    response = await device.session.cli(command="show platform trident forwarding-table partition", ofmt="json")
     logger.debug(f"query result is: {response}")
-    response_data = response[0]["uftMode"]
+    response_data = response["uftMode"]
     if response_data == mode:
         result.is_success()
     else:
@@ -55,7 +53,7 @@ def verify_unified_forwarding_table_mode(
 
 @skip_on_platforms(["cEOSLab", "VEOS-LAB"])
 @anta_test
-def verify_tcam_profile(
+async def verify_tcam_profile(
     device: InventoryDevice, profile: str, result: TestResult
 ) -> TestResult:
 
@@ -78,16 +76,16 @@ def verify_tcam_profile(
         result.is_skipped("verify_tcam_profile was not run as no profile was given")
         return result
 
-    response = device.session.runCmds(1, ["show hardware tcam profile"], "json")
+    response = await device.session.cli(command="show hardware tcam profile", ofmt="json")
     logger.debug(f"query result is: {response}")
     if (
-        response[0]["pmfProfiles"]["FixedSystem"]["status"]
-        == response[0]["pmfProfiles"]["FixedSystem"]["config"]
-    ) and (response[0]["pmfProfiles"]["FixedSystem"]["status"] == profile):
+        response["pmfProfiles"]["FixedSystem"]["status"]
+        == response["pmfProfiles"]["FixedSystem"]["config"]
+    ) and (response["pmfProfiles"]["FixedSystem"]["status"] == profile):
         result.is_success()
     else:
         result.is_failure(
-            f'Incorrect profile configured on device: {response[0]["pmfProfiles"]["FixedSystem"]["status"]}'
+            f'Incorrect profile configured on device: {response["pmfProfiles"]["FixedSystem"]["status"]}'
         )
 
     return result

--- a/anta/tests/profiles.py
+++ b/anta/tests/profiles.py
@@ -54,7 +54,7 @@ async def verify_unified_forwarding_table_mode(
 @skip_on_platforms(["cEOSLab", "VEOS-LAB"])
 @anta_test
 async def verify_tcam_profile(
-    device: InventoryDevice, profile: str, result: TestResult
+    device: InventoryDevice, result: TestResult, profile: str = None
 ) -> TestResult:
 
     """

--- a/anta/tests/profiles.py
+++ b/anta/tests/profiles.py
@@ -54,7 +54,7 @@ async def verify_unified_forwarding_table_mode(
 @skip_on_platforms(["cEOSLab", "VEOS-LAB"])
 @anta_test
 async def verify_tcam_profile(
-    device: InventoryDevice, result: TestResult, profile: str = None
+    device: InventoryDevice, result: TestResult, profile: str
 ) -> TestResult:
 
     """

--- a/anta/tests/routing/bgp.py
+++ b/anta/tests/routing/bgp.py
@@ -12,9 +12,9 @@ from anta.tests import anta_test
 logger = logging.getLogger(__name__)
 
 
-@check_bgp_family_enable("ipv4")
 @anta_test
-def verify_bgp_ipv4_unicast_state(
+@check_bgp_family_enable("ipv4")
+async def verify_bgp_ipv4_unicast_state(
     device: InventoryDevice, result: TestResult
 ) -> TestResult:
     """
@@ -33,12 +33,12 @@ def verify_bgp_ipv4_unicast_state(
         * result = "failure" otherwise.
         * result = "error" if any exception is caught
     """
-    response = device.session.runCmds(
-        1, ["show bgp ipv4 unicast summary vrf all"], "json"
+    response = await device.session.cli(
+        command="show bgp ipv4 unicast summary vrf all", ofmt="json"
     )
     logger.debug(f"query result is: {response}")
 
-    bgp_vrfs = response[0]["vrfs"]
+    bgp_vrfs = response["vrfs"]
 
     state_issue: Dict[str, Any] = {}
     for vrf in bgp_vrfs:
@@ -67,9 +67,9 @@ def verify_bgp_ipv4_unicast_state(
     return result
 
 
-@check_bgp_family_enable("ipv4")
 @anta_test
-def verify_bgp_ipv4_unicast_count(
+@check_bgp_family_enable("ipv4")
+async def verify_bgp_ipv4_unicast_count(
     device: InventoryDevice, result: TestResult, number: int, vrf: str = "default"
 ) -> TestResult:
     """
@@ -98,12 +98,12 @@ def verify_bgp_ipv4_unicast_count(
         )
         return result
 
-    response = device.session.runCmds(
-        1, [f"show bgp ipv4 unicast summary vrf {vrf}"], "json"
+    response = await device.session.cli(
+        command=f"show bgp ipv4 unicast summary vrf {vrf}", ofmt="json"
     )
     logger.debug(f"query result is: {response}")
 
-    bgp_vrfs = response[0]["vrfs"]
+    bgp_vrfs = response["vrfs"]
 
     peer_state_issue = {}
     peer_number = len(bgp_vrfs[vrf]["peers"])
@@ -132,9 +132,9 @@ def verify_bgp_ipv4_unicast_count(
     return result
 
 
-@check_bgp_family_enable("ipv6")
 @anta_test
-def verify_bgp_ipv6_unicast_state(
+@check_bgp_family_enable("ipv6")
+async def verify_bgp_ipv6_unicast_state(
     device: InventoryDevice, result: TestResult
 ) -> TestResult:
     """
@@ -153,12 +153,12 @@ def verify_bgp_ipv6_unicast_state(
         * result = "failure" otherwise.
         * result = "error" if any exception is caught
     """
-    response = device.session.runCmds(
-        1, ["show bgp ipv6 unicast summary vrf all"], "json"
+    response = await device.session.cli(
+        command="show bgp ipv6 unicast summary vrf all", ofmt="json"
     )
 
     logger.debug(f"query result is: {response}")
-    bgp_vrfs = response[0]["vrfs"]
+    bgp_vrfs = response["vrfs"]
 
     state_issue: Dict[str, Any] = {}
     for vrf in bgp_vrfs:
@@ -187,9 +187,9 @@ def verify_bgp_ipv6_unicast_state(
     return result
 
 
-@check_bgp_family_enable("evpn")
 @anta_test
-def verify_bgp_evpn_state(device: InventoryDevice, result: TestResult) -> TestResult:
+@check_bgp_family_enable("evpn")
+async def verify_bgp_evpn_state(device: InventoryDevice, result: TestResult) -> TestResult:
 
     """
     Verifies all EVPN BGP sessions are established (default VRF).
@@ -206,10 +206,10 @@ def verify_bgp_evpn_state(device: InventoryDevice, result: TestResult) -> TestRe
         * result = "error" if any exception is caught
 
     """
-    response = device.session.runCmds(1, ["show bgp evpn summary"], "json")
+    response = await device.session.cli(command="show bgp evpn summary", ofmt="json")
     logger.debug(f"query result is: {response}")
 
-    bgp_vrfs = response[0]["vrfs"]
+    bgp_vrfs = response["vrfs"]
 
     peers = bgp_vrfs["default"]["peers"]
     non_established_peers = [
@@ -228,9 +228,9 @@ def verify_bgp_evpn_state(device: InventoryDevice, result: TestResult) -> TestRe
     return result
 
 
-@check_bgp_family_enable("evpn")
 @anta_test
-def verify_bgp_evpn_count(
+@check_bgp_family_enable("evpn")
+async def verify_bgp_evpn_count(
     device: InventoryDevice, result: TestResult, number: int
 ) -> TestResult:
     """
@@ -257,10 +257,10 @@ def verify_bgp_evpn_count(
         )
         return result
 
-    response = device.session.runCmds(1, ["show bgp evpn summary"], "json")
+    response = await device.session.cli(command="show bgp evpn summary", ofmt="json")
     logger.debug(f"query result is: {response}")
 
-    peers = response[0]["vrfs"]["default"]["peers"]
+    peers = response["vrfs"]["default"]["peers"]
 
     if len(peers) == number:
         result.is_success()
@@ -274,9 +274,9 @@ def verify_bgp_evpn_count(
     return result
 
 
-@check_bgp_family_enable("rtc")
 @anta_test
-def verify_bgp_rtc_state(device: InventoryDevice, result: TestResult) -> TestResult:
+@check_bgp_family_enable("rtc")
+async def verify_bgp_rtc_state(device: InventoryDevice, result: TestResult) -> TestResult:
     """
     Verifies all RTC BGP sessions are established (default VRF).
 
@@ -292,10 +292,10 @@ def verify_bgp_rtc_state(device: InventoryDevice, result: TestResult) -> TestRes
         * result = "error" if any exception is caught
 
     """
-    response = device.session.runCmds(1, ["show bgp rt-membership summary"], "json")
+    response = await device.session.cli(command="show bgp rt-membership summary", ofmt="json")
     logger.debug(f"query result is: {response}")
 
-    peers = response[0]["vrfs"]["default"]["peers"]
+    peers = response["vrfs"]["default"]["peers"]
     non_established_peers = [
         peer
         for peer, peer_dict in peers.items()
@@ -312,9 +312,9 @@ def verify_bgp_rtc_state(device: InventoryDevice, result: TestResult) -> TestRes
     return result
 
 
-@check_bgp_family_enable("rtc")
 @anta_test
-def verify_bgp_rtc_count(
+@check_bgp_family_enable("rtc")
+async def verify_bgp_rtc_count(
     device: InventoryDevice, result: TestResult, number: int
 ) -> TestResult:
     """
@@ -341,10 +341,10 @@ def verify_bgp_rtc_count(
         )
         return result
 
-    response = device.session.runCmds(1, ["show bgp rt-membership summary"], "json")
+    response = await device.session.cli(command="show bgp rt-membership summary", ofmt="json")
     logger.debug(f"query result is: {response}")
 
-    peers = response[0]["vrfs"]["default"]["peers"]
+    peers = response["vrfs"]["default"]["peers"]
     non_established_peers = [
         peer
         for peer, peer_dict in peers.items()

--- a/anta/tests/routing/ospf.py
+++ b/anta/tests/routing/ospf.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 @anta_test
-def verify_ospf_state(device: InventoryDevice, result: TestResult) -> TestResult:
+async def verify_ospf_state(device: InventoryDevice, result: TestResult) -> TestResult:
     """
     Verifies all OSPF neighbors are in FULL state.
 
@@ -25,14 +25,14 @@ def verify_ospf_state(device: InventoryDevice, result: TestResult) -> TestResult
         * result = "failure" otherwise.
         * result = "error" if any exception is caught
     """
-    response = device.session.runCmds(
-        1, ["show ip ospf neighbor | exclude FULL|Address"], "text"
+    response = await device.session.cli(
+        command="show ip ospf neighbor | exclude FULL|Address", ofmt="text"
     )
     logger.debug(f"query result is: {response}")
-    if len(response[0]["output"]) == 0:
+    if len(response) == 0:
         result.is_skipped("no OSPF neighbor found")
         return result
-    if response[0]["output"].count("\n") == 0:
+    if response.count("\n") == 0:
         result.is_success()
     else:
         result.is_failure("Some neighbors are not correctly configured.")
@@ -41,7 +41,7 @@ def verify_ospf_state(device: InventoryDevice, result: TestResult) -> TestResult
 
 
 @anta_test
-def verify_ospf_count(
+async def verify_ospf_count(
     device: InventoryDevice, result: TestResult, number: int
 ) -> TestResult:
     """
@@ -65,14 +65,14 @@ def verify_ospf_count(
         )
         return result
 
-    response = device.session.runCmds(
-        1, ["show ip ospf neighbor | exclude  Address"], "text"
+    response = await device.session.cli(
+        command="show ip ospf neighbor | exclude  Address", ofmt="text"
     )
     logger.debug(f"query result is: {response}")
-    if len(response[0]["output"]) == 0:
+    if len(response) == 0:
         result.is_skipped("no OSPF neighbor found")
         return result
-    response_data = response[0]["output"].count("FULL")
+    response_data = response.count("FULL")
     if response_data.count("FULL") == number:
         result.is_success()
     else:

--- a/anta/tests/software.py
+++ b/anta/tests/software.py
@@ -13,9 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 @anta_test
-def verify_eos_version(
-    device: InventoryDevice, result: TestResult, versions: Optional[List[str]] = None
-) -> TestResult:
+async def verify_eos_version(device: InventoryDevice, result: TestResult, versions: Optional[List[str]] = None) -> TestResult:
     """
     Verifies the device is running one of the allowed EOS version.
 
@@ -36,10 +34,10 @@ def verify_eos_version(
         result.is_skipped("verify_eos_version was not run as no versions were given")
         return result
 
-    response = device.session.runCmds(1, ["show version"], "json")
+    response = await device.session.cli(command="show version", ofmt="json")
     logger.debug(f"query result is: {response}")
 
-    if response[0]["version"] in versions:
+    if response["version"] in versions:
         result.is_success()
     else:
         result.is_failure(

--- a/anta/tests/system.py
+++ b/anta/tests/system.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 @anta_test
-def verify_uptime(
+async def verify_uptime(
     device: InventoryDevice, result: TestResult, minimum: Optional[int] = None
 ) -> TestResult:
     """
@@ -35,10 +35,10 @@ def verify_uptime(
         result.is_skipped("verify_uptime was not run as no minimum were given")
         return result
 
-    response = device.session.runCmds(1, ["show uptime"], "json")
+    response = await device.session.cli(command="show uptime", ofmt="json")
     logger.debug(f"query result is: {response}")
-    response_data = response[0]["upTime"]
-    if response[0]["upTime"] > minimum:
+    response_data = response["upTime"]
+    if response["upTime"] > minimum:
         result.is_success()
     else:
         result.is_failure(f"Uptime is {response_data}")

--- a/anta/tests/system.py
+++ b/anta/tests/system.py
@@ -37,17 +37,18 @@ async def verify_uptime(
 
     response = await device.session.cli(command="show uptime", ofmt="json")
     logger.debug(f"query result is: {response}")
-    response_data = response["upTime"]
     if response["upTime"] > minimum:
         result.is_success()
     else:
-        result.is_failure(f"Uptime is {response_data}")
+        result.is_failure(f"Uptime is {response['upTime']}")
 
     return result
 
 
 @anta_test
-async def verify_reload_cause(device: InventoryDevice, result: TestResult) -> TestResult:
+async def verify_reload_cause(
+    device: InventoryDevice, result: TestResult
+) -> TestResult:
     """
     Verifies the last reload of the device was requested by a user.
 
@@ -105,9 +106,9 @@ async def verify_coredump(device: InventoryDevice, result: TestResult) -> TestRe
     response = await device.session.cli(
         commands=[
             {"cmd": "enable", "input": str(device.enable_password)},
-             "bash timeout 10 ls /var/core",
+            "bash timeout 10 ls /var/core",
         ],
-        ofmt="text"
+        ofmt="text",
     )
     logger.debug(f"query result is: {response}")
     response_data = response[1]
@@ -161,7 +162,9 @@ async def verify_syslog(device: InventoryDevice, result: TestResult) -> TestResu
         * result = "failure" otherwise.
         * result = "error" if any exception is caught
     """
-    response = await device.session.cli(command="show logging last 7 days threshold warnings", ofmt="text")
+    response = await device.session.cli(
+        command="show logging last 7 days threshold warnings", ofmt="text"
+    )
     logger.debug(f"query result is: {response}")
     if len(response) == 0:
         result.is_success()
@@ -174,7 +177,9 @@ async def verify_syslog(device: InventoryDevice, result: TestResult) -> TestResu
 
 
 @anta_test
-async def verify_cpu_utilization(device: InventoryDevice, result: TestResult) -> TestResult:
+async def verify_cpu_utilization(
+    device: InventoryDevice, result: TestResult
+) -> TestResult:
     """
     Verifies the CPU utilization is less than 75%.
 
@@ -245,12 +250,12 @@ async def verify_filesystem_utilization(
         * result = "failure" otherwise.
         * result = "error" if any exception is caught
     """
-    response = await device.session.cli(commands=
-        [
+    response = await device.session.cli(
+        commands=[
             {"cmd": "enable", "input": device.enable_password},
             "bash timeout 10 df -h",
         ],
-        ofmt="text"
+        ofmt="text",
     )
     logger.debug(f"query result is: {response}")
     result.is_success()

--- a/anta/tests/vxlan.py
+++ b/anta/tests/vxlan.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 @anta_test
-def verify_vxlan(device: InventoryDevice, result: TestResult) -> TestResult:
+async def verify_vxlan(device: InventoryDevice, result: TestResult) -> TestResult:
     """
     Verifies the interface vxlan 1 status is up/up.
 
@@ -26,16 +26,16 @@ def verify_vxlan(device: InventoryDevice, result: TestResult) -> TestResult:
         * result = "error" if any exception is caught
 
     """
-    response = device.session.runCmds(1, ["show interfaces description"], "json")
+    response = await device.session.cli(command="show interfaces description", ofmt="json")
     logger.debug(f"query result is: {response}")
 
-    response_data = response[0]["interfaceDescriptions"]
+    response_data = response["interfaceDescriptions"]
 
     if "Vxlan1" not in response_data:
         result.is_failure("No interface VXLAN 1 detected.")
     else:
         protocol_status = response_data["Vxlan1"]["lineProtocolStatus"]
-        interface_status = response_data["Vxlan1"]["intefraceStatus"]
+        interface_status = response_data["Vxlan1"]["interfaceStatus"]
         if protocol_status == "up" and interface_status == "up":
             result.is_success()
         else:
@@ -47,7 +47,7 @@ def verify_vxlan(device: InventoryDevice, result: TestResult) -> TestResult:
 
 
 @anta_test
-def verify_vxlan_config_sanity(
+async def verify_vxlan_config_sanity(
     device: InventoryDevice, result: TestResult
 ) -> TestResult:
     """
@@ -63,9 +63,9 @@ def verify_vxlan_config_sanity(
         * result = "failure" otherwise.
         * result = "error" if any exception is caught
     """
-    response = device.session.runCmds(1, ["show vxlan config-sanity"], "json")
+    response = await device.session.cli(command="show vxlan config-sanity", ofmt="json")
     logger.debug(f"query result is: {response}")
-    response_data = response[0]["categories"]
+    response_data = response["categories"]
 
     if len(response_data) == 0:
         result.is_skipped("Vxlan is not enabled on this device")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ commands =
   lint: pylint scripts
   type: mypy --config-file=pyproject.toml anta
   type: mypy --config-file=pyproject.toml scripts
-  test: pytest
+  test: pytest {tty:--color=yes}
 
 [testenv:clean]
 deps = coverage[toml]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,9 @@ warn_untyped_fields = true
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = clean,py{37,38,39,310}-{lint,type,test},report
+envlist = clean,py{38,39,310}-{lint,type,test},report
 [gh-actions]
 python =
-  3.7: py37
   3.8: py38
   3.9: py39
   3.10: py310, coverage

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ pytest-dependency
 pytest-html>=3.1.1
 pytest-metadata>=1.11.0
 pylint-pydantic>=0.1.4
-tox>=3.25.1
+tox==4.0.11
 types-PyYAML
 types-paramiko
 types-requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pydantic>=1.9.1
 Jinja2>=3.1.2
 tabulate>=0.8.10
 rich>=12.5.1
+aio-eapi==0.3.0

--- a/scripts/check-devices.py
+++ b/scripts/check-devices.py
@@ -245,8 +245,7 @@ if __name__ == "__main__":
         username=cli_options.username,
         password=cli_options.password,
         enable_password=cli_options.enable_password,
-        timeout=cli_options.timeout,
-        auto_connect=True,
+        timeout=cli_options.timeout
     )
 
     scope_tags = (

--- a/scripts/clear-counters.py
+++ b/scripts/clear-counters.py
@@ -80,8 +80,7 @@ def main() -> None:
         inventory_file=args.file,
         username=args.username,
         password=args.password,
-        auto_connect=True,
-        timeout=2,
+        timeout=2
     )
     clear_counters(inventory, args.enable_pass)
     report_unreachable_devices(inventory)

--- a/scripts/collect-eos-commands.py
+++ b/scripts/collect-eos-commands.py
@@ -96,8 +96,7 @@ def main() -> None:
         inventory_file=args.file,
         username=args.username,
         password=args.password,
-        auto_connect=True,
-        timeout=2,
+        timeout=2
     )
 
     devices = inventory.get_inventory(established_only=True)

--- a/scripts/collect-sheduled-show-tech.py
+++ b/scripts/collect-sheduled-show-tech.py
@@ -86,8 +86,7 @@ def main() -> None:
         inventory_file=args.file,
         username=args.username,
         password=args.password,
-        auto_connect=True,
-        timeout=2,
+        timeout=2
     )
 
     inv_size = inventory.get_inventory(established_only=False)

--- a/scripts/evpn-blacklist-recovery.py
+++ b/scripts/evpn-blacklist-recovery.py
@@ -72,8 +72,7 @@ def main() -> None:
         inventory_file=args.file,
         username=args.username,
         password=args.password,
-        auto_connect=True,
-        timeout=1,
+        timeout=1
     )
     clear_evpn_blacklisted_mac_addresses(inventory, args.enable_pass)
     report_unreachable_devices(inventory)

--- a/tests/data/json_data.py
+++ b/tests/data/json_data.py
@@ -16,11 +16,11 @@ INVENTORY_MODEL_HOST = [
         "expected_result": "invalid",
     },
     {
-        "name": "invalidIPv6_wit_netmask",
+        "name": "invalidIPv6_with_netmask",
         "input": "fe80::cc62:a9ff:feef:932a/128",
         "expected_result": "invalid",
     },
-    {"name": "invalidIPv4_format", "input": "1.1.1.1.1", "expected_result": "invalid"},
+    {"name": "invalidHost_format", "input": "@", "expected_result": "invalid"},
     {
         "name": "invalidIPv6_format",
         "input": "fe80::cc62:a9ff:feef:",
@@ -84,16 +84,12 @@ INVENTORY_DEVICE_MODEL = [
             {
                 "host": "1.1.1.1",
                 "username": "arista",
-                "password": "arista123!",
-                "established": False,
-                "url": "https://demo.io/fake/url",
+                "password": "arista123!"
             },
             {
                 "host": "1.1.1.2",
                 "username": "arista",
-                "password": "arista123!",
-                "established": False,
-                "url": "https://demo.io/fake/url",
+                "password": "arista123!"
             },
         ],
         "expected_result": "valid",
@@ -103,34 +99,25 @@ INVENTORY_DEVICE_MODEL = [
         "input": [
             {
                 "host": "1.1.1.1",
-                "password": "arista123!",
-                "established": False,
-                "url": "https://demo.io/fake/url",
+                "password": "arista123!"
             },
             {
                 "host": "1.1.1.1",
-                "username": "arista",
-                "established": False,
-                "url": "https://demo.io/fake/url",
+                "username": "arista"
             },
             {
                 "username": "arista",
-                "password": "arista123!",
-                "established": False,
-                "url": "https://demo.io/fake/url",
+                "password": "arista123!"
             },
             {
-                "host": "1.1.1.1",
+                "host": "@",
                 "username": "arista",
-                "password": "arista123!",
-                "established": False,
+                "password": "arista123!"
             },
             {
                 "host": "1.1.1.1/32",
                 "username": "arista",
-                "password": "arista123!",
-                "established": False,
-                "url": "https://demo.io/fake/url",
+                "password": "arista123!"
             },
         ],
         "expected_result": "invalid",

--- a/tests/scripts/rich.py
+++ b/tests/scripts/rich.py
@@ -290,8 +290,7 @@ if __name__ == "__main__":
         inventory_file=cli_options.inventory,
         username=cli_options.username,
         password=cli_options.password,
-        timeout=0.5,
-        auto_connect=True,
+        timeout=0.5
     )
     logger.info(f"Inventory {cli_options.inventory} loaded")
     if cli_options.verbose:

--- a/tests/units/conftest.py
+++ b/tests/units/conftest.py
@@ -7,7 +7,7 @@ import functools
 from unittest.mock import MagicMock, create_autospec
 
 import pytest
-
+from aioeapi import Device
 from anta.inventory.models import InventoryDevice
 
 
@@ -21,11 +21,10 @@ def mocked_device() -> MagicMock:
     mock.username = "toto"
     mock.password = "mysuperdupersecret"
     mock.enable_password = "mysuperduperenablesecret"
-    mock.session = MagicMock()
+    mock.session = create_autospec(Device)
     mock.is_online = True
     mock.established = True
     mock.hw_model = "unset"
-    mock.url = "https://42.42.42.42:666"
 
     # keeping the original assert_enable_password_is_not_none() method
     mock.assert_enable_password_is_not_none = functools.partial(

--- a/tests/units/conftest.py
+++ b/tests/units/conftest.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, create_autospec
 
 import pytest
 from aioeapi import Device
+
 from anta.inventory.models import InventoryDevice
 
 

--- a/tests/units/inventory_models_test.py
+++ b/tests/units/inventory_models_test.py
@@ -336,16 +336,12 @@ class Test_InventoryDeviceModel:
                  {
                      'host': '1.1.1.1',
                      'username': 'arista',
-                     'password': 'arista123!',
-                     'established': False,
-                     'url': 'https://demo.io/fake/url'
+                     'password': 'arista123!'
                  },
                  {
                      'host': '1.1.1.1',
                      'username': 'arista',
-                     'password': 'arista123!',
-                     'established': False,
-                     'url': 'https://demo.io/fake/url'
+                     'password': 'arista123!'
                  }
              ],
              "expected_result": "valid"
@@ -377,16 +373,12 @@ class Test_InventoryDeviceModel:
                  {
                      'host': '1.1.1.1',
                      'username': 'arista',
-                     'password': 'arista123!',
-                     'established': False,
-                     'url': 'https://demo.io/fake/url'
+                     'password': 'arista123!'
                  },
                  {
                      'host': '1.1.1.1',
                      'username': 'arista',
-                     'password': 'arista123!',
-                     'established': False,
-                     'url': 'https://demo.io/fake/url'
+                     'password': 'arista123!'
                  }
              ],
              "expected_result": "valid"
@@ -419,16 +411,12 @@ class Test_InventoryDeviceModel:
                  {
                      'host': '1.1.1.1',
                      'username': 'arista',
-                     'password': 'arista123!',
-                     'established': False,
-                     'url': 'https://demo.io/fake/url'
+                     'password': 'arista123!'
                  },
                  {
                      'host': '1.1.1.1',
                      'username': 'arista',
-                     'password': 'arista123!',
-                     'established': False,
-                     'url': 'https://demo.io/fake/url'
+                     'password': 'arista123!'
                  }
              ],
              "expected_result": "valid"
@@ -457,16 +445,12 @@ class Test_InventoryDeviceModel:
                  {
                      'host': '1.1.1.1',
                      'username': 'arista',
-                     'password': 'arista123!',
-                     'established': False,
-                     'url': 'https://demo.io/fake/url'
+                     'password': 'arista123!'
                  },
                  {
                      'host': '1.1.1.1',
                      'username': 'arista',
-                     'password': 'arista123!',
-                     'established': False,
-                     'url': 'https://demo.io/fake/url'
+                     'password': 'arista123!'
                  }
              ],
              "expected_result": "valid"
@@ -478,7 +462,7 @@ class Test_InventoryDeviceModel:
         inventory_devices = InventoryDevices()
         for entry in test_definition["input"]:
             inventory_devices.append(InventoryDevice(**entry))
-        if str(inventory_devices[0].host) == test_definition["input"][0]["host"]:
+        if str(inventory_devices[0].session.host) == test_definition["input"][0]["host"]:
             logging.info("__getitem__ function is valid")
         else:
             logging.error("__getitem__ is not working as expected")
@@ -499,16 +483,12 @@ class Test_InventoryDeviceModel:
                  {
                      'host': '1.1.1.1',
                      'username': 'arista',
-                     'password': 'arista123!',
-                     'established': False,
-                     'url': 'https://demo.io/fake/url'
+                     'password': 'arista123!'
                  },
                  {
                      'host': '1.1.1.1',
                      'username': 'arista',
-                     'password': 'arista123!',
-                     'established': False,
-                     'url': 'https://demo.io/fake/url'
+                     'password': 'arista123!'
                  }
              ],
              "expected_result": "valid"
@@ -521,7 +501,7 @@ class Test_InventoryDeviceModel:
         for entry in test_definition["input"]:
             inventory_devices.append(InventoryDevice(**entry))
         for idx, device in enumerate(inventory_devices):
-            if str(device.host) == test_definition["input"][idx]["host"]:
+            if str(device.session.host) == test_definition["input"][idx]["host"]:
                 logging.info("__iter__ function is valid")
             else:
                 logging.error("__iter__ is not working as expected")

--- a/tests/units/inventory_test.py
+++ b/tests/units/inventory_test.py
@@ -71,8 +71,7 @@ class Test_AntaInventory:
             AntaInventory(
                 inventory_file=inventory_file,
                 username="arista",
-                password="arista123",
-                auto_connect=False,
+                password="arista123"
             )
         except ValidationError as exc:
             logging.error("Exceptions is: %s", str(exc))
@@ -113,8 +112,7 @@ class Test_AntaInventory:
             AntaInventory(
                 inventory_file=inventory_file,
                 username="arista",
-                password="arista123",
-                auto_connect=False,
+                password="arista123"
             )
         except InventoryIncorrectSchema as exc:
             logging.warning("Exception is: %s", exc)
@@ -162,8 +160,7 @@ class Test_AntaInventory:
         inventory_test = AntaInventory(
             inventory_file=inventory_file,
             username="arista",
-            password="arista123",
-            auto_connect=False,
+            password="arista123"
         )
         logging.info(
             "Checking if %s is in inventory",
@@ -209,8 +206,7 @@ class Test_AntaInventory:
         inventory_test = AntaInventory(
             inventory_file=inventory_file,
             username="arista",
-            password="arista123",
-            auto_connect=False,
+            password="arista123"
         )
         logging.info(
             "Checking if %s is in inventory",
@@ -254,8 +250,7 @@ class Test_AntaInventory:
         inventory_test = AntaInventory(
             inventory_file=inventory_file,
             username="arista",
-            password="arista123",
-            auto_connect=False,
+            password="arista123"
         )
         logging.info(
             "Getting if %s from inventory",
@@ -310,8 +305,7 @@ class Test_AntaInventory:
         inventory_test = AntaInventory(
             inventory_file=inventory_file,
             username="arista",
-            password="arista123",
-            auto_connect=False,
+            password="arista123"
         )
         inventory_json = json.loads(
             str(inventory_test.get_inventory(format_out="json", established_only=False))

--- a/tests/units/test_tests/test_configuration.py
+++ b/tests/units/test_tests/test_configuration.py
@@ -5,13 +5,15 @@
 """
 Tests for anta.tests.configuration.py
 """
+import asyncio
 from typing import Any, Dict, List
 from unittest.mock import MagicMock
 
 import pytest
 from jsonrpclib.jsonrpc import AppError
-import asyncio
-from anta.tests.configuration import verify_zerotouch, verify_running_config_diffs
+
+from anta.tests.configuration import (verify_running_config_diffs,
+                                      verify_zerotouch)
 
 
 @pytest.mark.parametrize(

--- a/tests/units/test_tests/test_configuration.py
+++ b/tests/units/test_tests/test_configuration.py
@@ -12,8 +12,7 @@ from unittest.mock import MagicMock
 import pytest
 from jsonrpclib.jsonrpc import AppError
 
-from anta.tests.configuration import (verify_running_config_diffs,
-                                      verify_zerotouch)
+from anta.tests.configuration import verify_running_config_diffs, verify_zerotouch
 
 
 @pytest.mark.parametrize(
@@ -28,8 +27,12 @@ from anta.tests.configuration import (verify_running_config_diffs,
             id="failure",
         ),
         # Hmmmm both errors do not return the same string ...
-        pytest.param(None, AppError("dummy"), "error", ["dummy"], id="JSON RPC error"),
-        pytest.param(None, KeyError("dummy"), "error", ["'dummy'"], id="Key error"),
+        pytest.param(
+            None, AppError("dummy"), "error", ["AppError: dummy"], id="JSON RPC error"
+        ),
+        pytest.param(
+            None, KeyError("dummy"), "error", ["KeyError: 'dummy'"], id="Key error"
+        ),
     ],
 )
 def test_verify_zerotouch(
@@ -65,22 +68,34 @@ def test_verify_zerotouch(
             None,
             False,
             "failure",
-            ['blah', 'blah'],
+            ["blah", "blah"],
             id="failure",
         ),
         # Hmmmm both errors do not return the same string ...
         pytest.param(
-            None, AppError("dummy"), False, "error", ["dummy"], id="JSON RPC error"
+            None,
+            AppError("dummy"),
+            False,
+            "error",
+            ["AppError: dummy"],
+            id="JSON RPC error",
         ),
         pytest.param(
-            None, KeyError("dummy"), False, "error", ["'dummy'"], id="Key error"
+            None,
+            KeyError("dummy"),
+            False,
+            "error",
+            ["KeyError: 'dummy'"],
+            id="Key error",
         ),
         pytest.param(
             None,
             None,
             True,
             "error",
-            ["verify_running_config_diffs requires `enable_password` to be set"],
+            [
+                "ValueError: verify_running_config_diffs requires `enable_password` to be set"
+            ],
             id="Missing enable password",
         ),
     ],

--- a/tests/units/test_tests/test_configuration.py
+++ b/tests/units/test_tests/test_configuration.py
@@ -12,7 +12,8 @@ from unittest.mock import MagicMock
 import pytest
 from jsonrpclib.jsonrpc import AppError
 
-from anta.tests.configuration import verify_running_config_diffs, verify_zerotouch
+from anta.tests.configuration import (verify_running_config_diffs,
+                                      verify_zerotouch)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Using asyncio framework will help improving performances when running tests on a large network with a high number of tests.
First step is to refactor the anta.inventory module to use an async library, this PR tries an attempt with [aio-eapi](https://github.com/jeremyschulman/aio-eapi).
This PR must also refactor all the tests as coroutines and modify the scripts to run the asyncio event loop.

---

### Modifications to `anta.inventory`

The session attribute of InventoryDevice is now a aioeapi.Device object.
auto_connect is removed from the constructor: this would cause to run an asyncio event loop in an object constructor and prevent fine control from a ANTA user script on the asyncio scheduling.

`_is_device_online()` uses `aioeapi.Device.check_connection()` to only tries to open a port on the device.
`_ refresh_device_fact()` updates all the device flags and reduce the number of API calls compared to the previous implementation.

`connect_inventory()` is a coroutine that needs to be called in a ANTA user script to establish connection towards the devices.

```
async def main():
   await anta_inventory.connect_inventory()
```

---

When using a containerlab topology on macOS, we need to use port forwarding to localhost to access eAPI endpoints.
The current inventory only supports IP addresses. This PR supports hostnames (DNS names instead of IP), ports and alias names in the inventory.

The following inventory works with this PR:

```
anta_inventory:
  hosts:
  - name: spine1
    host: localhost
    port: 44301
  - name: spine2
    host: localhost
    port: 44302
  - name: leaf1
    host: localhost
    port: 44311
  - name: leaf1
    host: localhost
    port: 44312
  - name: leaf3
    host: localhost
    port: 44313
  - name: leaf4
    host: localhost
    port: 44314
 ```