### PR TITLE
fix: Rename field in get_hosts() to match updated TestResult model

### DIFF
--- a/anta/result_manager/__init__.py
+++ b/anta/result_manager/__init__.py
@@ -160,12 +160,12 @@ class ResultManager:
             f'retrieve list of result using output_format {output_format} for host {host_ip}')
         if output_format == "list":
             return [
-                result for result in self._result_entries if str(result.host) == host_ip
+                result for result in self._result_entries if str(result.name) == host_ip
             ]
 
         result_manager_filtered = ListResult()
         for result in self._result_entries:
-            if str(result.host) == host_ip:
+            if str(result.name) == host_ip:
                 result_manager_filtered.append(result)
         return result_manager_filtered
 
@@ -194,7 +194,7 @@ class ResultManager:
         logger.info('build list of host ip registered in result-manager')
         result_list = []
         for testcase in self._result_entries:
-            if str(testcase.host) not in result_list:
-                result_list.append(str(testcase.host))
+            if str(testcase.name) not in result_list:
+                result_list.append(str(testcase.name))
         logger.debug(f'list of tests name: {result_list}')
         return result_list

--- a/anta/tests/__init__.py
+++ b/anta/tests/__init__.py
@@ -38,7 +38,7 @@ def anta_test(function: Callable[..., Coroutine[Any, Any, TestResult]]) -> Calla
             * result = "failure" otherwise.
             * result = "error" if any exception is caught
         """
-        result = TestResult(name=str(device.host), test=function.__name__)
+        result = TestResult(name=device.name, test=function.__name__)
         logger.debug(f"Start {function.__name__} check for host {device.host}")
 
         try:


### PR DESCRIPTION
Fixing issue #128

- rename `testcase.host` by `testcase.name` in `get_hosts()` 
- rename `result.host` by `result.name` in`get_result_by_host()`
