### PR TITLE
feat(check-devices): Update default logging behavior

### DIFF
--- a/scripts/check-devices.py
+++ b/scripts/check-devices.py
@@ -50,8 +50,12 @@ def setup_logging(level: str) -> None:
     * anta.result_manager
     * check-devices
 
+    By default, configure INFO for the script,
+    WARNING for anta.inventory and anta.report_manager
+    and CRITICAL for others
+
     Args:
-        level (str, optional): level name to configure. Defaults to 'critical'.
+        level (str): level name to configure.
     """
 
     if level is not None:
@@ -222,7 +226,7 @@ def cli_manager() -> argparse.Namespace:
     parser.add_argument(
         "-log",
         "--loglevel",
-        help="Provide logging level. Example --loglevel debug, default=none",
+        help="Provide logging level. Example --loglevel debug, By default INFO only for the script, others are configured to WARNING and CRITICAL",
     )
 
     return parser.parse_args()

--- a/scripts/check-devices.py
+++ b/scripts/check-devices.py
@@ -41,7 +41,7 @@ from anta.runner import main
 logger = logging.getLogger(__name__)
 
 
-def setup_logging(level: str = "info") -> None:
+def setup_logging(level: str) -> None:
     """
     Configure logging for check-devices execution
 
@@ -54,7 +54,7 @@ def setup_logging(level: str = "info") -> None:
         level (str, optional): level name to configure. Defaults to 'critical'.
     """
 
-    if level.upper() != 'UNSET':
+    if level is not None:
         loglevel = getattr(logging, level.upper())
     else:
         loglevel = getattr(logging, 'WARNING')
@@ -84,7 +84,7 @@ def setup_logging(level: str = "info") -> None:
     logger.setLevel(loglevel)
 
     # Set default logging
-    if level.upper() == "UNSET":
+    if level is None:
         logger.setLevel(logging.INFO)
 
 
@@ -222,8 +222,7 @@ def cli_manager() -> argparse.Namespace:
     parser.add_argument(
         "-log",
         "--loglevel",
-        default="unset",
-        help="Provide logging level. Example --loglevel debug, default=info",
+        help="Provide logging level. Example --loglevel debug, default=none",
     )
 
     return parser.parse_args()

--- a/scripts/check-devices.py
+++ b/scripts/check-devices.py
@@ -53,7 +53,11 @@ def setup_logging(level: str = "info") -> None:
     Args:
         level (str, optional): level name to configure. Defaults to 'critical'.
     """
-    loglevel = getattr(logging, level.upper())
+
+    if level.upper() != 'UNSET':
+        loglevel = getattr(logging, level.upper())
+    else:
+        loglevel = getattr(logging, 'WARNING')
 
     FORMAT = "%(message)s"
     logging.basicConfig(
@@ -78,6 +82,10 @@ def setup_logging(level: str = "info") -> None:
     logging.getLogger("anta.tests.routing.ospf").setLevel(logging.ERROR)
 
     logger.setLevel(loglevel)
+
+    # Set default logging
+    if level.upper() == "UNSET":
+        logger.setLevel(logging.INFO)
 
 
 def cli_manager() -> argparse.Namespace:
@@ -214,7 +222,7 @@ def cli_manager() -> argparse.Namespace:
     parser.add_argument(
         "-log",
         "--loglevel",
-        default="info",
+        default="unset",
         help="Provide logging level. Example --loglevel debug, default=info",
     )
 


### PR DESCRIPTION
Update default logging behaviour to not list all tests addition in result manager by default

- Configure `INFO` only for `check-devices.py` script
- Configure `WARNING` for `anta.inventory` module
- Configure `WARNING` for `anta.result_manager` module

To change logging for `anta.inventory` & `anta.result_manager`, `--loglevel` option can be used