### PR TITLE
fix: Add missing sub-module in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,10 +85,14 @@ anta = "anta.cli.cli:cli"
 packages=[
   "anta",
   "anta.cli",
+  "anta.cli.check",
+  "anta.cli.exec",
+  "anta.cli.inventory",
   "anta.inventory",
   "anta.reporter",
   "anta.result_manager",
   "anta.tests",
+  "anta.tests.routing",
   "scripts"
 ]
 


### PR DESCRIPTION
Fix an issue where submodules where not correctly installed when using `pip`.
