### PR TITLE
fix(anta.tests): Allow verify_running_config to support no enable pasword

### DIFF
--- a/anta/tests/configuration.py
+++ b/anta/tests/configuration.py
@@ -57,15 +57,24 @@ async def verify_running_config_diffs(
         * result = "error" if any exception is caught
 
     """
-    device.assert_enable_password_is_not_none("verify_running_config_diffs")
-
-    response = await device.session.cli(
-        commands=[
-            {"cmd": "enable", "input": str(device.enable_password)},
-            "show running-config diffs",
-        ],
-        ofmt="text"
-    )
+    if device.enable_password is not None:
+        device.assert_enable_password_is_not_none(
+            "verify_running_config_diffs")
+        response = await device.session.cli(
+            commands=[
+                {"cmd": "enable", "input": str(device.enable_password)},
+                "show running-config diffs",
+            ],
+            ofmt="text"
+        )
+    else:
+        response = await device.session.cli(
+            commands=[
+                {"cmd": "enable"},
+                "show running-config diffs",
+            ],
+            ofmt="text"
+        )
 
     logger.debug(f"query result is: {response}")
 

--- a/anta/tests/configuration.py
+++ b/anta/tests/configuration.py
@@ -58,21 +58,14 @@ async def verify_running_config_diffs(
 
     """
     if device.enable_password is not None:
-        response = await device.session.cli(
-            commands=[
-                {"cmd": "enable", "input": str(device.enable_password)},
-                "show running-config diffs",
-            ],
-            ofmt="text"
-        )
+        enable_cmd = {"cmd": "enable", "input": str(device.enable_password)}
     else:
-        response = await device.session.cli(
-            commands=[
-                {"cmd": "enable"},
-                "show running-config diffs",
-            ],
-            ofmt="text"
-        )
+         enable_cmd = "enable"
+    commands = [enable_cmd, "show running-config diffs"]
+    response = await device.session.cli(
+        commands=commands,
+        ofmt="text",
+    )
 
     logger.debug(f"query result is: {response}")
 

--- a/anta/tests/configuration.py
+++ b/anta/tests/configuration.py
@@ -60,7 +60,7 @@ async def verify_running_config_diffs(
     if device.enable_password is not None:
         enable_cmd = {"cmd": "enable", "input": str(device.enable_password)}
     else:
-         enable_cmd = "enable"
+         enable_cmd = {"cmd": "enable"}
     commands = [enable_cmd, "show running-config diffs"]
     response = await device.session.cli(
         commands=commands,

--- a/anta/tests/configuration.py
+++ b/anta/tests/configuration.py
@@ -60,7 +60,7 @@ async def verify_running_config_diffs(
     if device.enable_password is not None:
         enable_cmd = {"cmd": "enable", "input": str(device.enable_password)}
     else:
-         enable_cmd = {"cmd": "enable"}
+        enable_cmd = {"cmd": "enable"}
     commands = [enable_cmd, "show running-config diffs"]
     response = await device.session.cli(
         commands=commands,

--- a/anta/tests/configuration.py
+++ b/anta/tests/configuration.py
@@ -58,8 +58,6 @@ async def verify_running_config_diffs(
 
     """
     if device.enable_password is not None:
-        device.assert_enable_password_is_not_none(
-            "verify_running_config_diffs")
         response = await device.session.cli(
             commands=[
                 {"cmd": "enable", "input": str(device.enable_password)},

--- a/tests/units/test_tests/test_configuration.py
+++ b/tests/units/test_tests/test_configuration.py
@@ -87,14 +87,12 @@ def test_verify_zerotouch(
             id="Key error",
         ),
         pytest.param(
+            [None, []],
             None,
-            None,
-            True,
-            "error",
-            [
-                "ValueError (verify_running_config_diffs requires `enable_password` to be set)"
-            ],
-            id="Missing enable password",
+            False,
+            "success",
+            [],
+            id="success",
         ),
     ],
 )


### PR DESCRIPTION
Allow to run `verify_running_config` whitout setting a fake enable password if not configured in CLI.